### PR TITLE
```git feat: add donation transaction outcomes and project details pa…

### DIFF
--- a/app/(main)/projects/[id]/loading.tsx
+++ b/app/(main)/projects/[id]/loading.tsx
@@ -1,0 +1,51 @@
+export default function ProjectDetailsLoading() {
+  return (
+    <div className="min-h-screen bg-[#f0f4fa] pt-24">
+      <div className="border-b border-neutral-200 bg-white">
+        <div className="container mx-auto max-w-[1280px] px-4 py-5">
+          <div className="h-5 w-72 animate-pulse rounded bg-neutral-100" />
+        </div>
+      </div>
+
+      <main className="container mx-auto max-w-[1280px] px-4 py-8 lg:py-12">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_390px]">
+          <div className="space-y-8">
+            <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
+              <div className="mb-5 space-y-4">
+                <div className="h-6 w-40 animate-pulse rounded-full bg-neutral-100" />
+                <div className="h-12 w-3/4 animate-pulse rounded bg-neutral-100" />
+                <div className="h-5 w-full animate-pulse rounded bg-neutral-100" />
+                <div className="h-5 w-2/3 animate-pulse rounded bg-neutral-100" />
+              </div>
+              <div className="aspect-[16/9] animate-pulse rounded-xl bg-neutral-100" />
+            </section>
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+              <div className="h-8 w-48 animate-pulse rounded bg-neutral-100" />
+              <div className="mt-5 space-y-3">
+                <div className="h-4 w-full animate-pulse rounded bg-neutral-100" />
+                <div className="h-4 w-full animate-pulse rounded bg-neutral-100" />
+                <div className="h-4 w-3/4 animate-pulse rounded bg-neutral-100" />
+              </div>
+            </section>
+          </div>
+
+          <aside className="space-y-5">
+            <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
+              <div className="h-5 w-36 animate-pulse rounded bg-neutral-100" />
+              <div className="mt-4 h-10 w-48 animate-pulse rounded bg-neutral-100" />
+              <div className="mt-5 h-4 w-full animate-pulse rounded-full bg-neutral-100" />
+              <div className="mt-5 grid grid-cols-3 gap-3">
+                <div className="h-24 animate-pulse rounded-lg bg-neutral-100" />
+                <div className="h-24 animate-pulse rounded-lg bg-neutral-100" />
+                <div className="h-24 animate-pulse rounded-lg bg-neutral-100" />
+              </div>
+            </section>
+            <div className="h-44 animate-pulse rounded-xl border border-neutral-200 bg-white" />
+          </aside>
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/app/(main)/projects/[id]/page.tsx
+++ b/app/(main)/projects/[id]/page.tsx
@@ -1,0 +1,215 @@
+import { notFound } from 'next/navigation';
+import { ProjectDetailsClient } from '@/components/projects/ProjectDetailsClient';
+import type { Project, ProjectCreator, ProjectStatus, Update } from '@/types/api';
+
+export const dynamic = 'force-dynamic';
+
+interface ProjectPageProps {
+  params: {
+    id: string;
+  };
+}
+
+type ProjectApiPayload = Partial<Project> & {
+  raised?: string | number;
+  goal?: string | number;
+  fundingGoal?: string | number;
+  target?: string | number;
+  images?: string[];
+  creatorName?: string;
+  creator?: ProjectCreator;
+  updates?: Update[];
+};
+
+const FALLBACK_IMAGES = [
+  'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1400&q=80',
+  'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80',
+  'https://images.unsplash.com/photo-1497486751825-1233686d5d80?auto=format&fit=crop&w=1400&q=80',
+  'https://images.unsplash.com/photo-1469571486292-0ba58a3f068b?auto=format&fit=crop&w=1400&q=80',
+  'https://images.unsplash.com/photo-1509391366360-2e959784a276?auto=format&fit=crop&w=1400&q=80',
+];
+
+const CATEGORIES = ['Environment', 'Health', 'Education', 'Disaster Relief', 'Energy', 'Community'];
+
+function toStringAmount(value: string | number | undefined, fallback = '0') {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+
+  return fallback;
+}
+
+function toNumber(value: string | number | undefined, fallback = 0) {
+  const numeric = Number(value ?? fallback);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function toStatus(value: unknown): ProjectStatus {
+  if (value === 'completed' || value === 'almost-funded' || value === 'paused' || value === 'draft') {
+    return value;
+  }
+
+  return 'active';
+}
+
+function normalizeProject(payload: ProjectApiPayload, id: string): Project {
+  const targetAmount = toStringAmount(payload.targetAmount ?? payload.goal ?? payload.fundingGoal ?? payload.target, '50000');
+  const currentAmount = toStringAmount(payload.currentAmount ?? payload.raised, '0');
+  const createdAt = payload.createdAt || new Date().toISOString();
+  const imageUrls = payload.imageUrls?.length ? payload.imageUrls : payload.images || [];
+  const creatorId = payload.creatorId || payload.creator?.id || `creator-${id}`;
+
+  return {
+    ...payload,
+    id: String(payload.id || id),
+    title: payload.title || 'Untitled Project',
+    description: payload.description || 'Project details are being prepared by the campaign creator.',
+    targetAmount,
+    currentAmount,
+    creatorId,
+    imageUrl: payload.imageUrl || imageUrls[0],
+    imageUrls,
+    category: payload.category || 'Community',
+    status: toStatus(payload.status),
+    donorCount: payload.donorCount ?? payload.donors ?? 0,
+    creator: payload.creator || {
+      id: creatorId,
+      name: payload.creatorName || 'StellarAid Creator',
+      verified: Boolean(payload.isVerified),
+    },
+    createdAt,
+    updatedAt: payload.updatedAt || createdAt,
+  };
+}
+
+function getFallbackIndex(id: string) {
+  if (/^\d+$/.test(id)) {
+    const numericId = Number(id);
+    return numericId >= 1 && numericId <= 60 ? numericId - 1 : null;
+  }
+
+  const projectMatch = id.match(/^project-(\d+)-(\d+)$/);
+  if (projectMatch) {
+    return (Number(projectMatch[1]) - 1) * 9 + Number(projectMatch[2]);
+  }
+
+  const featuredMatch = id.match(/^featured-(\d+)$/);
+  if (featuredMatch) {
+    return Number(featuredMatch[1]);
+  }
+
+  if (/^proj_\d+$/.test(id)) {
+    return 6;
+  }
+
+  return null;
+}
+
+function createFallbackProject(id: string): Project | null {
+  const index = getFallbackIndex(id);
+  if (index === null) {
+    return null;
+  }
+
+  const category = CATEGORIES[index % CATEGORIES.length];
+  const targetAmount = 20000 + (index % 8) * 7500;
+  const progress = Math.min(28 + (index * 13) % 71, 97);
+  const currentAmount = Math.round((targetAmount * progress) / 100);
+  const daysRemaining = 7 + (index % 6) * 6;
+  const deadline = new Date(Date.now() + daysRemaining * 86400000).toISOString();
+  const imageUrl = FALLBACK_IMAGES[index % FALLBACK_IMAGES.length];
+
+  return normalizeProject(
+    {
+      id,
+      title: `${category} Impact Campaign`,
+      summary: `A verified campaign advancing ${category.toLowerCase()} outcomes with transparent Stellar donations.`,
+      description:
+        `This campaign supports measurable ${category.toLowerCase()} work through local partners, community reporting, and transparent donation tracking on Stellar.`,
+      story:
+        `The project team is coordinating resources, volunteers, and field partners to deliver practical help where it is needed most. Donations help cover supplies, logistics, and follow-up reporting so supporters can see the campaign's progress.`,
+      impact:
+        `Every contribution moves the campaign closer to its goal and helps the creator publish more updates for donors.`,
+      targetAmount: String(targetAmount),
+      currentAmount: String(currentAmount),
+      creatorId: `creator-${index + 1}`,
+      imageUrl,
+      imageUrls: [imageUrl, FALLBACK_IMAGES[(index + 1) % FALLBACK_IMAGES.length]],
+      category,
+      status: progress > 90 ? 'almost-funded' : 'active',
+      isVerified: index % 2 === 0,
+      isUrgent: index % 5 === 0,
+      donorCount: 48 + index * 7,
+      deadline,
+      daysRemaining,
+      location: ['Lagos, Nigeria', 'Quito, Ecuador', 'Accra, Ghana', 'Manila, Philippines'][index % 4],
+      creator: {
+        id: `creator-${index + 1}`,
+        name: ['Maya Okoro', 'Daniel Rivera', 'Amina Cole', 'Samir Patel'][index % 4],
+        bio: 'Campaign organizer coordinating verified updates, local delivery, and donor reporting.',
+        location: ['Lagos, Nigeria', 'Quito, Ecuador', 'Accra, Ghana', 'Manila, Philippines'][index % 4],
+        verified: index % 2 === 0,
+      },
+      updates: [
+        {
+          id: `${id}-update-1`,
+          campaignId: id,
+          title: 'Milestone report published',
+          content: 'The creator shared a field update with current needs, delivery progress, and the next funding milestone.',
+          imageUrls: [imageUrl],
+          createdAt: new Date(Date.now() - 3 * 86400000).toISOString(),
+        },
+        {
+          id: `${id}-update-2`,
+          campaignId: id,
+          title: 'Campaign kickoff',
+          content: 'The project was reviewed and opened for StellarAid donations.',
+          createdAt: new Date(Date.now() - 11 * 86400000).toISOString(),
+        },
+      ],
+      createdAt: new Date(Date.now() - 14 * 86400000).toISOString(),
+      updatedAt: new Date(Date.now() - 3 * 86400000).toISOString(),
+    },
+    id
+  );
+}
+
+async function fetchProject(id: string): Promise<Project | null> {
+  const apiBaseUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api').replace(/\/+$/, '');
+
+  try {
+    const response = await fetch(`${apiBaseUrl}/projects/${encodeURIComponent(id)}`, {
+      cache: 'no-store',
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Project API returned ${response.status}`);
+    }
+
+    const json = (await response.json()) as { data?: ProjectApiPayload } | ProjectApiPayload;
+    const wrappedPayload = json as { data?: ProjectApiPayload };
+    const payload = wrappedPayload.data || (json as ProjectApiPayload);
+
+    return normalizeProject(payload, id);
+  } catch {
+    return createFallbackProject(id);
+  }
+}
+
+export default async function ProjectDetailsPage({ params }: ProjectPageProps) {
+  const project = await fetchProject(params.id);
+
+  if (!project) {
+    notFound();
+  }
+
+  return <ProjectDetailsClient project={project} />;
+}

--- a/components/donations/DonationModal.tsx
+++ b/components/donations/DonationModal.tsx
@@ -1,9 +1,21 @@
+/* eslint-disable @next/next/no-img-element */
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from '@/components/ui';
 import { AssetSelector, SUPPORTED_ASSETS, type DonationAsset } from './AssetSelector';
+import {
+  TransactionSuccessModal,
+  type DonationReceipt,
+} from './TransactionSuccessModal';
+import {
+  TransactionErrorModal,
+  type TransactionErrorDetails,
+  createTransactionErrorDetails,
+} from './TransactionErrorModal';
 import { Heart, Info } from 'lucide-react';
+import { useWalletStore } from '@/store/walletStore';
 
 export interface DonationModalProps {
   isOpen: boolean;
@@ -13,7 +25,9 @@ export interface DonationModalProps {
     title: string;
     imageUrl?: string;
   };
-  onDonate?: (payload: DonationPayload) => Promise<void>;
+  onDonate?: (payload: DonationPayload) => Promise<DonationResult | void>;
+  onSuccess?: (receipt: DonationReceipt) => void;
+  onSendConfirmationEmail?: (receipt: DonationReceipt) => Promise<void>;
 }
 
 export interface DonationPayload {
@@ -24,16 +38,53 @@ export interface DonationPayload {
   anonymous: boolean;
 }
 
+export interface DonationResult {
+  id?: string;
+  txHash?: string;
+  transactionHash?: string;
+  createdAt?: string;
+  amount?: string | number;
+  assetCode?: string;
+}
+
 const QUICK_AMOUNTS = [5, 10, 25, 50];
 const TX_FEE_XLM = 0.00001;
 
-export function DonationModal({ isOpen, onClose, project, onDonate }: DonationModalProps) {
+function generateTransactionHash() {
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2)}`.padEnd(64, '0').slice(0, 64);
+}
+
+function getDonationAmount(result: DonationResult | void, fallbackAmount: number) {
+  if (!result?.amount) return fallbackAmount;
+  const amount = Number(result.amount);
+  return Number.isFinite(amount) ? amount : fallbackAmount;
+}
+
+export function DonationModal({
+  isOpen,
+  onClose,
+  project,
+  onDonate,
+  onSuccess,
+  onSendConfirmationEmail,
+}: DonationModalProps) {
+  const router = useRouter();
+  const walletBalance = useWalletStore((state) => state.balance);
+  const walletAddress = useWalletStore((state) => state.address);
   const [rawAmount, setRawAmount] = useState('');
   const [selectedAsset, setSelectedAsset] = useState<DonationAsset>(SUPPORTED_ASSETS[0]);
   const [message, setMessage] = useState('');
   const [anonymous, setAnonymous] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const [receipt, setReceipt] = useState<DonationReceipt | null>(null);
+  const [transactionError, setTransactionError] = useState<TransactionErrorDetails | null>(null);
 
   const amount = parseFloat(rawAmount) || 0;
   const usdEquivalent = (amount * selectedAsset.usdRate).toFixed(2);
@@ -65,20 +116,118 @@ export function DonationModal({ isOpen, onClose, project, onDonate }: DonationMo
     return true;
   }
 
+  function getSpendableBalanceError() {
+    if (!walletAddress || selectedAsset.code !== 'XLM' || !walletBalance) {
+      return null;
+    }
+
+    const balance = Number(walletBalance);
+    if (!Number.isFinite(balance)) {
+      return null;
+    }
+
+    const requiredAmount = amount + TX_FEE_XLM;
+    if (requiredAmount > balance) {
+      return new Error('Insufficient balance for this donation amount and the Stellar network fee.');
+    }
+
+    return null;
+  }
+
+  function buildReceipt(result: DonationResult | void): DonationReceipt {
+    const donationAmount = getDonationAmount(result, amount);
+    const txHash = result?.transactionHash || result?.txHash || generateTransactionHash();
+
+    return {
+      donationId: result?.id,
+      projectId: project.id,
+      projectTitle: project.title,
+      amount: donationAmount,
+      assetCode: result?.assetCode || selectedAsset.code,
+      usdEquivalent: donationAmount * selectedAsset.usdRate,
+      transactionHash: txHash,
+      donatedAt: result?.createdAt || new Date().toISOString(),
+      donorName: anonymous ? undefined : 'Connected donor',
+      anonymous,
+      message: message.trim() || undefined,
+      networkFee: `${TX_FEE_XLM} XLM`,
+    };
+  }
+
+  async function sendConfirmationEmail(receiptDetails: DonationReceipt) {
+    if (onSendConfirmationEmail) {
+      await onSendConfirmationEmail(receiptDetails);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 5000);
+    const apiBaseUrl = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api').replace(/\/+$/, '');
+    try {
+      const response = await fetch(`${apiBaseUrl}/donations/confirmation-email`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+        body: JSON.stringify({
+          donationId: receiptDetails.donationId,
+          projectId: receiptDetails.projectId,
+          projectTitle: receiptDetails.projectTitle,
+          amount: String(receiptDetails.amount),
+          asset: receiptDetails.assetCode,
+          txHash: receiptDetails.transactionHash,
+          donatedAt: receiptDetails.donatedAt,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Confirmation email request failed with status ${response.status}`);
+      }
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
   async function handleSubmit() {
     if (!validate()) return;
     setIsSubmitting(true);
     try {
-      await onDonate?.({
+      const balanceError = getSpendableBalanceError();
+      if (balanceError) {
+        throw balanceError;
+      }
+
+      const payload = {
         projectId: project.id,
         amount,
         asset: selectedAsset,
         message,
         anonymous,
+      };
+      const result = await onDonate?.(payload);
+      const receiptDetails = buildReceipt(result);
+
+      setReceipt(receiptDetails);
+      onSuccess?.(receiptDetails);
+      setError('');
+    } catch (donationError) {
+      const details = createTransactionErrorDetails(donationError, {
+        projectId: project.id,
+        projectTitle: project.title,
+        amount,
+        assetCode: selectedAsset.code,
       });
-      handleClose();
-    } catch {
-      setError('Donation failed. Please try again.');
+
+      setTransactionError(details);
+      console.error('[Donation] Failed to submit transaction', {
+        error: donationError,
+        projectId: project.id,
+        projectTitle: project.title,
+        amount,
+        assetCode: selectedAsset.code,
+        supportCode: details.supportCode,
+      });
     } finally {
       setIsSubmitting(false);
     }
@@ -86,10 +235,46 @@ export function DonationModal({ isOpen, onClose, project, onDonate }: DonationMo
 
   function handleClose() {
     setRawAmount('');
+    setSelectedAsset(SUPPORTED_ASSETS[0]);
     setMessage('');
     setAnonymous(false);
     setError('');
+    setReceipt(null);
+    setTransactionError(null);
     onClose();
+  }
+
+  function handleRetry() {
+    setTransactionError(null);
+    setError('');
+  }
+
+  function handleDonateAnother() {
+    handleClose();
+    router.push('/projects');
+  }
+
+  if (receipt) {
+    return (
+      <TransactionSuccessModal
+        isOpen={isOpen}
+        onClose={handleClose}
+        receipt={receipt}
+        onDonateAnother={handleDonateAnother}
+        onSendConfirmationEmail={sendConfirmationEmail}
+      />
+    );
+  }
+
+  if (transactionError) {
+    return (
+      <TransactionErrorModal
+        isOpen={isOpen}
+        error={transactionError}
+        onRetry={handleRetry}
+        onCancel={handleClose}
+      />
+    );
   }
 
   return (
@@ -98,6 +283,7 @@ export function DonationModal({ isOpen, onClose, project, onDonate }: DonationMo
       onClose={handleClose}
       variant="centered"
       size="md"
+      showCloseButton={false}
       aria-labelledby="donation-modal-title"
     >
       <ModalHeader onClose={handleClose} showCloseButton>

--- a/components/donations/TransactionErrorModal.tsx
+++ b/components/donations/TransactionErrorModal.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  AlertTriangle,
+  Clock,
+  HelpCircle,
+  RefreshCw,
+  ShieldAlert,
+  WalletCards,
+  WifiOff,
+  XCircle,
+} from 'lucide-react';
+import { Modal, ModalBody, ModalFooter, ModalHeader, Button } from '@/components/ui';
+
+export type TransactionFailureType =
+  | 'insufficient_balance'
+  | 'timeout'
+  | 'rejected'
+  | 'network'
+  | 'wallet'
+  | 'unknown';
+
+export interface TransactionErrorDetails {
+  type: TransactionFailureType;
+  message: string;
+  rawMessage?: string;
+  projectId?: string;
+  projectTitle?: string;
+  amount?: number;
+  assetCode?: string;
+  supportCode?: string;
+}
+
+interface TransactionErrorModalProps {
+  isOpen: boolean;
+  error: TransactionErrorDetails;
+  onRetry: () => void;
+  onCancel: () => void;
+}
+
+const TYPE_COPY: Record<
+  TransactionFailureType,
+  {
+    title: string;
+    description: string;
+    icon: React.ElementType;
+    reasons: string[];
+    tips: string[];
+  }
+> = {
+  insufficient_balance: {
+    title: 'Insufficient balance',
+    description: 'Your wallet does not have enough available funds for this donation and network fee.',
+    icon: WalletCards,
+    reasons: [
+      'The donation amount is higher than your spendable balance.',
+      'A small XLM reserve is required for Stellar accounts.',
+      'The selected asset may not be available in this wallet.',
+    ],
+    tips: [
+      'Try a smaller amount.',
+      'Switch to another supported asset.',
+      'Add funds to your wallet, then retry the donation.',
+    ],
+  },
+  timeout: {
+    title: 'Transaction timed out',
+    description: 'The Stellar network did not confirm the transaction before the request expired.',
+    icon: Clock,
+    reasons: [
+      'The wallet approval took too long.',
+      'Network confirmation was delayed.',
+      'The browser tab lost connectivity during submission.',
+    ],
+    tips: [
+      'Check whether your wallet shows a completed transaction.',
+      'Refresh your wallet balance.',
+      'Try again in a moment if no transaction was created.',
+    ],
+  },
+  rejected: {
+    title: 'Transaction cancelled',
+    description: 'The transaction was rejected or cancelled before it reached the network.',
+    icon: XCircle,
+    reasons: [
+      'The wallet approval prompt was declined.',
+      'The wallet window was closed.',
+      'The signing session expired.',
+    ],
+    tips: [
+      'Open your wallet before retrying.',
+      'Approve the donation when the wallet prompt appears.',
+      'Confirm the destination and amount before signing.',
+    ],
+  },
+  network: {
+    title: 'Network connection issue',
+    description: 'StellarAid could not reach the donation service or Stellar network.',
+    icon: WifiOff,
+    reasons: [
+      'Your internet connection changed during submission.',
+      'The donation API did not respond in time.',
+      'The Stellar Horizon endpoint may be temporarily unavailable.',
+    ],
+    tips: [
+      'Check your internet connection.',
+      'Wait a few seconds, then retry.',
+      'Avoid closing the wallet approval window while the transaction submits.',
+    ],
+  },
+  wallet: {
+    title: 'Wallet issue',
+    description: 'Your wallet could not sign or submit this transaction.',
+    icon: ShieldAlert,
+    reasons: [
+      'The wallet is disconnected or locked.',
+      'The active wallet account changed.',
+      'The selected asset may require a trustline.',
+    ],
+    tips: [
+      'Reconnect or unlock your wallet.',
+      'Confirm you are using the intended Stellar account.',
+      'Choose XLM if the selected asset is not configured.',
+    ],
+  },
+  unknown: {
+    title: 'Donation failed',
+    description: 'Something went wrong before the donation could be confirmed.',
+    icon: AlertTriangle,
+    reasons: [
+      'The wallet, API, or network returned an unexpected error.',
+      'The transaction may have been interrupted.',
+      'The campaign details may have changed during submission.',
+    ],
+    tips: [
+      'Retry the donation once.',
+      'Check your wallet activity for a matching transaction.',
+      'Contact support with the code below if the issue continues.',
+    ],
+  },
+};
+
+function extractMessage(error: unknown) {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as { message?: unknown }).message || '');
+  }
+  return '';
+}
+
+export function classifyTransactionError(error: unknown): TransactionFailureType {
+  const message = extractMessage(error).toLowerCase();
+
+  if (message.includes('insufficient') || message.includes('balance') || message.includes('reserve')) {
+    return 'insufficient_balance';
+  }
+  if (message.includes('timeout') || message.includes('timed out') || message.includes('expired')) {
+    return 'timeout';
+  }
+  if (
+    message.includes('reject') ||
+    message.includes('denied') ||
+    message.includes('declined') ||
+    message.includes('cancel')
+  ) {
+    return 'rejected';
+  }
+  if (
+    message.includes('network') ||
+    message.includes('fetch') ||
+    message.includes('econn') ||
+    message.includes('enotfound') ||
+    message.includes('horizon')
+  ) {
+    return 'network';
+  }
+  if (
+    message.includes('wallet') ||
+    message.includes('freighter') ||
+    message.includes('albedo') ||
+    message.includes('lobstr') ||
+    message.includes('trustline') ||
+    message.includes('sign')
+  ) {
+    return 'wallet';
+  }
+
+  return 'unknown';
+}
+
+export function createTransactionErrorDetails(
+  error: unknown,
+  context: Omit<TransactionErrorDetails, 'type' | 'message' | 'rawMessage' | 'supportCode'>
+): TransactionErrorDetails {
+  const type = classifyTransactionError(error);
+  const supportCode = `SA-${Date.now().toString(36).toUpperCase()}`;
+  const rawMessage = extractMessage(error);
+
+  return {
+    ...context,
+    type,
+    message: TYPE_COPY[type].description,
+    rawMessage,
+    supportCode,
+  };
+}
+
+function logTransactionFailure(error: Error, context: Record<string, unknown>) {
+  console.error('[Donation] Transaction failure', { error, ...context });
+
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const sentry = (
+    window as Window & {
+      Sentry?: {
+        captureException?: (capturedError: Error, options?: { extra?: Record<string, unknown> }) => void;
+      };
+    }
+  ).Sentry;
+
+  sentry?.captureException?.(error, { extra: context });
+}
+
+export function TransactionErrorModal({
+  isOpen,
+  error,
+  onRetry,
+  onCancel,
+}: TransactionErrorModalProps) {
+  const loggedCodeRef = useRef<string | null>(null);
+  const copy = TYPE_COPY[error.type] || TYPE_COPY.unknown;
+  const Icon = copy.icon;
+
+  const supportHref = useMemo(() => {
+    const subject = encodeURIComponent(`Donation failed: ${error.supportCode || 'no support code'}`);
+    const body = encodeURIComponent(
+      [
+        'Hi StellarAid support,',
+        '',
+        'I need help with a failed donation transaction.',
+        '',
+        `Support code: ${error.supportCode || 'Unavailable'}`,
+        `Project: ${error.projectTitle || error.projectId || 'Unavailable'}`,
+        error.amount && error.assetCode ? `Amount: ${error.amount} ${error.assetCode}` : null,
+        error.rawMessage ? `Error: ${error.rawMessage}` : null,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    );
+
+    return `mailto:support@stellaraid.org?subject=${subject}&body=${body}`;
+  }, [error]);
+
+  useEffect(() => {
+    if (!isOpen || loggedCodeRef.current === error.supportCode) {
+      return;
+    }
+
+    loggedCodeRef.current = error.supportCode || null;
+    logTransactionFailure(new Error(error.rawMessage || error.message), {
+      type: 'donation-transaction-failure',
+      failureType: error.type,
+      supportCode: error.supportCode,
+      projectId: error.projectId,
+      projectTitle: error.projectTitle,
+      amount: error.amount,
+      assetCode: error.assetCode,
+    });
+  }, [error, isOpen]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      variant="centered"
+      size="lg"
+      showCloseButton={false}
+      aria-labelledby="transaction-error-title"
+      className="max-h-[92vh] overflow-y-auto"
+    >
+      <ModalHeader onClose={onCancel} showCloseButton>
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-danger-50 text-danger-500">
+            <Icon className="h-6 w-6" />
+          </div>
+          <div>
+            <h2 id="transaction-error-title" className="text-lg font-semibold text-neutral-900">
+              {copy.title}
+            </h2>
+            <p className="text-sm text-neutral-500">Your donation was not completed.</p>
+          </div>
+        </div>
+      </ModalHeader>
+
+      <ModalBody className="space-y-6">
+        <div className="rounded-xl border border-danger-100 bg-danger-50 p-4 text-sm text-danger-700">
+          {error.rawMessage || error.message}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <section className="rounded-xl border border-neutral-200 bg-white p-4">
+            <h3 className="flex items-center gap-2 text-sm font-semibold text-neutral-900">
+              <HelpCircle className="h-4 w-4 text-neutral-400" />
+              Common reasons
+            </h3>
+            <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+              {copy.reasons.map((reason) => (
+                <li key={reason} className="flex gap-2">
+                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-300" />
+                  <span>{reason}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-xl border border-neutral-200 bg-white p-4">
+            <h3 className="flex items-center gap-2 text-sm font-semibold text-neutral-900">
+              <RefreshCw className="h-4 w-4 text-neutral-400" />
+              Troubleshooting
+            </h3>
+            <ul className="mt-3 space-y-2 text-sm text-neutral-600">
+              {copy.tips.map((tip) => (
+                <li key={tip} className="flex gap-2">
+                  <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-400" />
+                  <span>{tip}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <div className="rounded-xl bg-neutral-50 px-3 py-2 text-sm text-neutral-600">
+          <span className="font-semibold text-neutral-900">Support code:</span>{' '}
+          <span className="font-mono">{error.supportCode || 'Unavailable'}</span>
+        </div>
+      </ModalBody>
+
+      <ModalFooter className="flex-col items-stretch sm:flex-row sm:justify-between">
+        <a
+          href={supportHref}
+          className="inline-flex items-center justify-center rounded-lg border-2 border-blue-600 px-4 py-2 text-base font-medium text-blue-600 transition hover:bg-blue-50"
+        >
+          Contact Support
+        </a>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Return to Project
+          </Button>
+          <Button type="button" onClick={onRetry} className="gap-2">
+            <RefreshCw className="h-4 w-4" />
+            Try Again
+          </Button>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default TransactionErrorModal;

--- a/components/donations/TransactionSuccessModal.tsx
+++ b/components/donations/TransactionSuccessModal.tsx
@@ -1,0 +1,371 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { FaFacebookF, FaLinkedinIn, FaWhatsapp, FaXTwitter } from 'react-icons/fa6';
+import {
+  Check,
+  Copy,
+  Download,
+  ExternalLink,
+  Heart,
+  Mail,
+  RotateCcw,
+  Share2,
+} from 'lucide-react';
+import { Modal, ModalBody, ModalFooter, ModalHeader, Button } from '@/components/ui';
+import { getStellarExplorerTxUrl } from '@/lib/stellar/explorer';
+
+export interface DonationReceipt {
+  donationId?: string;
+  projectId: string;
+  projectTitle: string;
+  amount: number;
+  assetCode: string;
+  usdEquivalent: number;
+  transactionHash: string;
+  donatedAt: string;
+  donorName?: string;
+  anonymous?: boolean;
+  message?: string;
+  networkFee?: string;
+}
+
+interface TransactionSuccessModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  receipt: DonationReceipt;
+  onDonateAnother?: () => void;
+  onSendConfirmationEmail?: (receipt: DonationReceipt) => Promise<void>;
+}
+
+const CONFETTI_COLORS = ['#3461f9', '#fbbb25', '#10b981', '#8b5cf6', '#f97316'];
+
+function formatDonationAmount(amount: number, assetCode: string) {
+  return `${amount.toLocaleString(undefined, {
+    minimumFractionDigits: amount % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 7,
+  })} ${assetCode}`;
+}
+
+function formatUsd(amount: number) {
+  return amount.toLocaleString(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function shortHash(hash: string) {
+  return `${hash.slice(0, 8)}...${hash.slice(-8)}`;
+}
+
+function buildReceiptText(receipt: DonationReceipt) {
+  return [
+    'StellarAid Donation Receipt',
+    '',
+    `Donation ID: ${receipt.donationId || 'Pending confirmation'}`,
+    `Project: ${receipt.projectTitle}`,
+    `Project ID: ${receipt.projectId}`,
+    `Amount: ${formatDonationAmount(receipt.amount, receipt.assetCode)}`,
+    `USD Equivalent: ${formatUsd(receipt.usdEquivalent)}`,
+    `Transaction Hash: ${receipt.transactionHash}`,
+    `Explorer: ${getStellarExplorerTxUrl(receipt.transactionHash)}`,
+    `Date: ${new Date(receipt.donatedAt).toLocaleString()}`,
+    `Donor: ${receipt.anonymous ? 'Anonymous' : receipt.donorName || 'StellarAid donor'}`,
+    receipt.networkFee ? `Network Fee: ${receipt.networkFee}` : null,
+    receipt.message ? `Message: ${receipt.message}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function TransactionSuccessModal({
+  isOpen,
+  onClose,
+  receipt,
+  onDonateAnother,
+  onSendConfirmationEmail,
+}: TransactionSuccessModalProps) {
+  const [copied, setCopied] = useState(false);
+  const [shareUrl, setShareUrl] = useState('');
+  const [emailStatus, setEmailStatus] = useState<'idle' | 'sending' | 'sent' | 'failed'>('idle');
+  const emailedHashRef = useRef<string | null>(null);
+
+  const explorerUrl = getStellarExplorerTxUrl(receipt.transactionHash);
+  const shareText = `I just donated ${formatDonationAmount(receipt.amount, receipt.assetCode)} to ${receipt.projectTitle} on StellarAid.`;
+
+  const confetti = useMemo(
+    () =>
+      Array.from({ length: 18 }, (_, index) => ({
+        id: index,
+        left: `${8 + ((index * 23) % 84)}%`,
+        color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+        delay: `${(index % 6) * 0.11}s`,
+        duration: `${1.7 + (index % 4) * 0.15}s`,
+        rotate: `${(index % 2 === 0 ? 1 : -1) * (25 + index * 7)}deg`,
+      })),
+    []
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setShareUrl(`${window.location.origin}/projects/${receipt.projectId}`);
+  }, [isOpen, receipt.projectId]);
+
+  useEffect(() => {
+    if (!isOpen || !onSendConfirmationEmail || emailedHashRef.current === receipt.transactionHash) {
+      return;
+    }
+
+    emailedHashRef.current = receipt.transactionHash;
+    setEmailStatus('sending');
+
+    onSendConfirmationEmail(receipt)
+      .then(() => setEmailStatus('sent'))
+      .catch(() => setEmailStatus('failed'));
+  }, [isOpen, onSendConfirmationEmail, receipt]);
+
+  async function handleCopyHash() {
+    try {
+      await navigator.clipboard.writeText(receipt.transactionHash);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  function handleDownloadReceipt() {
+    const blob = new Blob([buildReceiptText(receipt)], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+
+    link.href = url;
+    link.download = `stellaraid-receipt-${shortHash(receipt.transactionHash)}.txt`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const encodedText = encodeURIComponent(shareText);
+  const encodedUrl = encodeURIComponent(shareUrl);
+  const shareLinks = {
+    x: `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+    whatsapp: `https://wa.me/?text=${encodedText}%20${encodedUrl}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+  };
+
+  const receiptRows = [
+    ['Project', receipt.projectTitle],
+    ['Amount', formatDonationAmount(receipt.amount, receipt.assetCode)],
+    ['USD value', formatUsd(receipt.usdEquivalent)],
+    ['Date', new Date(receipt.donatedAt).toLocaleString()],
+    ['Donor', receipt.anonymous ? 'Anonymous' : receipt.donorName || 'StellarAid donor'],
+    ['Network fee', receipt.networkFee || 'Estimated at submission'],
+  ];
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      variant="centered"
+      size="lg"
+      showCloseButton={false}
+      aria-labelledby="transaction-success-title"
+      className="max-h-[92vh] overflow-y-auto"
+    >
+      <style>{`
+        @keyframes tx-confetti-fall {
+          0% { opacity: 0; transform: translate3d(0, -36px, 0) rotate(0deg) scale(0.8); }
+          15% { opacity: 1; }
+          100% { opacity: 0; transform: translate3d(0, 92px, 0) rotate(var(--tx-rotate)) scale(1); }
+        }
+
+        @keyframes tx-success-pop {
+          0% { transform: scale(0.72); opacity: 0; }
+          65% { transform: scale(1.08); opacity: 1; }
+          100% { transform: scale(1); opacity: 1; }
+        }
+
+        .tx-confetti-piece {
+          animation: tx-confetti-fall var(--tx-duration) cubic-bezier(0.2, 0.8, 0.2, 1) infinite;
+          animation-delay: var(--tx-delay);
+        }
+
+        .tx-success-mark {
+          animation: tx-success-pop 520ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+        }
+      `}</style>
+
+      <ModalHeader onClose={onClose} showCloseButton>
+        <div className="flex items-center gap-3">
+          <div className="relative h-11 w-11 shrink-0">
+            {confetti.map((piece) => (
+              <span
+                key={piece.id}
+                className="tx-confetti-piece absolute top-0 h-2.5 w-1.5 rounded-sm"
+                style={
+                  {
+                    left: piece.left,
+                    backgroundColor: piece.color,
+                    '--tx-delay': piece.delay,
+                    '--tx-duration': piece.duration,
+                    '--tx-rotate': piece.rotate,
+                  } as React.CSSProperties
+                }
+              />
+            ))}
+            <span className="tx-success-mark absolute inset-1 flex items-center justify-center rounded-full bg-success-500 text-white shadow-stellar">
+              <Check className="h-6 w-6" />
+            </span>
+          </div>
+          <div>
+            <h2 id="transaction-success-title" className="text-lg font-semibold text-neutral-900">
+              Donation confirmed
+            </h2>
+            <p className="text-sm text-neutral-500">Your Stellar transaction was successful.</p>
+          </div>
+        </div>
+      </ModalHeader>
+
+      <ModalBody className="space-y-6">
+        <div className="rounded-xl border border-success-100 bg-success-50 p-4">
+          <p className="text-sm font-semibold text-success-700">You donated</p>
+          <p className="mt-1 text-3xl font-extrabold text-neutral-900">
+            {formatDonationAmount(receipt.amount, receipt.assetCode)}
+          </p>
+          <p className="mt-1 text-sm text-neutral-600">
+            to <span className="font-semibold text-neutral-900">{receipt.projectTitle}</span>
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-neutral-900">Transaction Hash</h3>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleCopyHash}
+              className="gap-2 text-sm"
+            >
+              <Copy className="h-4 w-4" />
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 font-mono text-xs text-neutral-700 break-all">
+            {receipt.transactionHash}
+          </div>
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary-600 hover:text-primary-700"
+          >
+            View on Stellar explorer
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </div>
+
+        <div className="rounded-xl border border-neutral-200 bg-white p-4">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h3 className="text-sm font-semibold text-neutral-900">Receipt</h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleDownloadReceipt}
+              className="gap-2"
+            >
+              <Download className="h-4 w-4" />
+              Download
+            </Button>
+          </div>
+          <dl className="grid gap-3 sm:grid-cols-2">
+            {receiptRows.map(([label, value]) => (
+              <div key={label} className="rounded-lg bg-neutral-50 px-3 py-2">
+                <dt className="text-xs font-medium uppercase text-neutral-400">{label}</dt>
+                <dd className="mt-1 text-sm font-semibold text-neutral-900">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
+          <div className="flex items-start gap-2 rounded-xl border border-primary-100 bg-primary-50 px-3 py-2 text-sm text-primary-700">
+            <Mail className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              {emailStatus === 'sending' && 'Sending your confirmation email...'}
+              {emailStatus === 'sent' && 'Confirmation email sent.'}
+              {emailStatus === 'failed' && 'Email delivery will be retried by support.'}
+              {emailStatus === 'idle' && 'A confirmation email will be sent to your account.'}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="sr-only">Share donation</span>
+            <a
+              href={shareLinks.x}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+              aria-label="Share on X"
+            >
+              <FaXTwitter className="h-4 w-4" />
+            </a>
+            <a
+              href={shareLinks.facebook}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+              aria-label="Share on Facebook"
+            >
+              <FaFacebookF className="h-4 w-4" />
+            </a>
+            <a
+              href={shareLinks.whatsapp}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+              aria-label="Share on WhatsApp"
+            >
+              <FaWhatsapp className="h-4 w-4" />
+            </a>
+            <a
+              href={shareLinks.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+              aria-label="Share on LinkedIn"
+            >
+              <FaLinkedinIn className="h-4 w-4" />
+            </a>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 rounded-xl bg-neutral-50 px-3 py-2 text-sm text-neutral-600">
+          <Share2 className="h-4 w-4 shrink-0 text-neutral-400" />
+          <span>Share your support to help this campaign reach more donors.</span>
+        </div>
+      </ModalBody>
+
+      <ModalFooter className="flex-col items-stretch sm:flex-row sm:justify-between">
+        <Button type="button" variant="outline" onClick={onDonateAnother} className="gap-2">
+          <RotateCcw className="h-4 w-4" />
+          Donate to Another Project
+        </Button>
+        <Button type="button" onClick={onClose} className="gap-2">
+          <Heart className="h-4 w-4" />
+          Done
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default TransactionSuccessModal;
+

--- a/components/projects/FundingProgress.tsx
+++ b/components/projects/FundingProgress.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { CalendarDays, CheckCircle2, TrendingUp, Users } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface FundingProgressProps {
+  currentAmount: number | string;
+  targetAmount: number | string;
+  donorCount?: number;
+  daysRemaining?: number;
+  className?: string;
+  onRefresh?: () => void;
+  autoRefreshIntervalMs?: number;
+}
+
+function toNumber(value: number | string | undefined) {
+  const numeric = Number(value || 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function formatMoney(value: number) {
+  return value.toLocaleString(undefined, {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+}
+
+function getFundingStage(percentage: number) {
+  if (percentage >= 100) {
+    return {
+      label: 'Funded',
+      bar: 'from-success-500 to-emerald-400',
+      badge: 'bg-success-50 text-success-700',
+      message: 'Goal reached',
+    };
+  }
+
+  if (percentage >= 90) {
+    return {
+      label: 'Final push',
+      bar: 'from-secondary-400 to-warning-500',
+      badge: 'bg-warning-50 text-warning-700',
+      message: 'Almost there!',
+    };
+  }
+
+  if (percentage >= 65) {
+    return {
+      label: 'Strong momentum',
+      bar: 'from-primary-500 to-success-500',
+      badge: 'bg-primary-50 text-primary-700',
+      message: 'Almost there!',
+    };
+  }
+
+  if (percentage >= 30) {
+    return {
+      label: 'Building support',
+      bar: 'from-primary-500 to-accent-500',
+      badge: 'bg-primary-50 text-primary-700',
+      message: 'Momentum is growing',
+    };
+  }
+
+  return {
+    label: 'Getting started',
+    bar: 'from-neutral-700 to-primary-500',
+    badge: 'bg-neutral-100 text-neutral-700',
+    message: 'Early support matters',
+  };
+}
+
+export function FundingProgress({
+  currentAmount,
+  targetAmount,
+  donorCount = 0,
+  daysRemaining,
+  className,
+  onRefresh,
+  autoRefreshIntervalMs,
+}: FundingProgressProps) {
+  const [isMounted, setIsMounted] = useState(false);
+  const current = toNumber(currentAmount);
+  const target = toNumber(targetAmount);
+  const percentage = target > 0 ? Math.min(Math.round((current / target) * 100), 100) : 0;
+  const stage = getFundingStage(percentage);
+
+  const milestones = useMemo(
+    () => [
+      { value: 25, label: '25%' },
+      { value: 50, label: '50%' },
+      { value: 75, label: 'Almost there!' },
+      { value: 100, label: 'Funded' },
+    ],
+    []
+  );
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!onRefresh || !autoRefreshIntervalMs) {
+      return;
+    }
+
+    const interval = window.setInterval(onRefresh, autoRefreshIntervalMs);
+    return () => window.clearInterval(interval);
+  }, [autoRefreshIntervalMs, onRefresh]);
+
+  return (
+    <section className={clsx('rounded-xl border border-neutral-200 bg-white p-5 shadow-sm', className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-neutral-500">Funding Progress</p>
+          <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <span className="text-3xl font-extrabold text-neutral-900">{formatMoney(current)}</span>
+            <span className="text-sm font-medium text-neutral-500">raised of {formatMoney(target)}</span>
+          </div>
+        </div>
+        <span className={clsx('rounded-full px-3 py-1 text-xs font-bold uppercase', stage.badge)}>
+          {stage.label}
+        </span>
+      </div>
+
+      <div className="mt-5" aria-live="polite">
+        <div className="mb-2 flex items-center justify-between text-sm">
+          <span className="font-semibold text-neutral-600">{stage.message}</span>
+          <span className="font-extrabold text-neutral-900">{percentage}%</span>
+        </div>
+        <div className="relative h-4 overflow-hidden rounded-full bg-neutral-100">
+          <div
+            className={clsx(
+              'h-full rounded-full bg-gradient-to-r transition-all duration-1000 ease-out',
+              stage.bar
+            )}
+            style={{ width: `${isMounted ? percentage : 0}%` }}
+          />
+          {milestones.map((milestone) => (
+            <span
+              key={milestone.value}
+              className={clsx(
+                'absolute top-1/2 h-5 w-px -translate-y-1/2 bg-white/80',
+                milestone.value === 100 ? 'right-0' : ''
+              )}
+              style={milestone.value === 100 ? undefined : { left: `${milestone.value}%` }}
+              aria-hidden="true"
+            />
+          ))}
+        </div>
+        <div className="mt-2 grid grid-cols-4 text-[10px] font-semibold uppercase text-neutral-400">
+          {milestones.map((milestone) => (
+            <span
+              key={milestone.value}
+              className={clsx(
+                milestone.value === 100 && 'text-right',
+                milestone.value === 75 && 'text-center',
+                milestone.value === 50 && 'text-center'
+              )}
+            >
+              {milestone.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-5 grid grid-cols-3 gap-3">
+        <div className="rounded-lg bg-neutral-50 px-3 py-3">
+          <Users className="h-4 w-4 text-primary-500" />
+          <p className="mt-2 text-lg font-extrabold text-neutral-900">{donorCount.toLocaleString()}</p>
+          <p className="text-xs font-medium text-neutral-500">Donors</p>
+        </div>
+        <div className="rounded-lg bg-neutral-50 px-3 py-3">
+          <CalendarDays className="h-4 w-4 text-warning-500" />
+          <p className="mt-2 text-lg font-extrabold text-neutral-900">
+            {typeof daysRemaining === 'number' ? Math.max(daysRemaining, 0) : 'Open'}
+          </p>
+          <p className="text-xs font-medium text-neutral-500">Days left</p>
+        </div>
+        <div className="rounded-lg bg-neutral-50 px-3 py-3">
+          {percentage >= 100 ? (
+            <CheckCircle2 className="h-4 w-4 text-success-500" />
+          ) : (
+            <TrendingUp className="h-4 w-4 text-accent-500" />
+          )}
+          <p className="mt-2 text-lg font-extrabold text-neutral-900">
+            {formatMoney(Math.max(target - current, 0))}
+          </p>
+          <p className="text-xs font-medium text-neutral-500">Remaining</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default FundingProgress;
+

--- a/components/projects/ProjectDetailsClient.tsx
+++ b/components/projects/ProjectDetailsClient.tsx
@@ -1,0 +1,397 @@
+/* eslint-disable @next/next/no-img-element */
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { FaFacebookF, FaLinkedinIn, FaWhatsapp, FaXTwitter } from 'react-icons/fa6';
+import {
+  BadgeCheck,
+  CalendarDays,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Heart,
+  Mail,
+  MapPin,
+  Share2,
+  ShieldCheck,
+  Sparkles,
+  UserRound,
+  Zap,
+} from 'lucide-react';
+import { clsx } from 'clsx';
+import { DonationModal } from '@/components/donations/DonationModal';
+import type { DonationReceipt } from '@/components/donations/TransactionSuccessModal';
+import { FundingProgress } from '@/components/projects/FundingProgress';
+import { ImageGallery, type GalleryImage } from '@/components/projects/ImageGallery';
+import type { Project, Update } from '@/types/api';
+
+interface ProjectDetailsClientProps {
+  project: Project;
+}
+
+function toNumber(value: string | number | undefined) {
+  const numeric = Number(value || 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function getDaysRemaining(project: Project) {
+  if (typeof project.daysRemaining === 'number') {
+    return project.daysRemaining;
+  }
+
+  if (!project.deadline) {
+    return undefined;
+  }
+
+  const deadline = new Date(project.deadline).getTime();
+  if (!Number.isFinite(deadline)) {
+    return undefined;
+  }
+
+  const remaining = Math.ceil((deadline - Date.now()) / 86400000);
+  return Math.max(remaining, 0);
+}
+
+function getDonorCount(project: Project) {
+  return project.donorCount ?? project.donors ?? 0;
+}
+
+function getProjectImages(project: Project): GalleryImage[] {
+  const urls = project.imageUrls?.length ? project.imageUrls : project.imageUrl ? [project.imageUrl] : [];
+
+  return urls.map((url, index) => ({
+    src: url,
+    alt: `${project.title} image ${index + 1}`,
+    caption: index === 0 ? project.title : `Campaign image ${index + 1}`,
+  }));
+}
+
+function getUpdates(project: Project, images: GalleryImage[]): Update[] {
+  if (project.updates?.length) {
+    return project.updates;
+  }
+
+  return [
+    {
+      id: `${project.id}-launch`,
+      campaignId: project.id,
+      title: 'Campaign launched',
+      content: `${project.title} is now accepting donations from StellarAid supporters.`,
+      imageUrls: images[0]?.src ? [images[0].src] : [],
+      createdAt: project.createdAt,
+    },
+  ];
+}
+
+function formatDate(value: string) {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function ProjectDetailsClient({ project }: ProjectDetailsClientProps) {
+  const [projectState, setProjectState] = useState(project);
+  const [isDonationOpen, setIsDonationOpen] = useState(false);
+  const [shareUrl, setShareUrl] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  const images = useMemo(() => getProjectImages(projectState), [projectState]);
+  const updates = useMemo(() => getUpdates(projectState, images), [projectState, images]);
+  const currentAmount = toNumber(projectState.currentAmount);
+  const targetAmount = toNumber(projectState.targetAmount);
+  const donorCount = getDonorCount(projectState);
+  const daysRemaining = getDaysRemaining(projectState);
+  const creator = projectState.creator;
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
+
+  function handleDonationSuccess(receipt: DonationReceipt) {
+    setProjectState((current) => ({
+      ...current,
+      currentAmount: String(toNumber(current.currentAmount) + receipt.usdEquivalent),
+      donorCount: getDonorCount(current) + 1,
+    }));
+  }
+
+  async function handleNativeShare() {
+    if (navigator.share) {
+      await navigator.share({
+        title: projectState.title,
+        text: projectState.summary || projectState.description,
+        url: shareUrl || window.location.href,
+      });
+    }
+  }
+
+  async function handleCopyLink() {
+    try {
+      await navigator.clipboard.writeText(shareUrl || window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  const encodedUrl = encodeURIComponent(shareUrl);
+  const encodedText = encodeURIComponent(`Support ${projectState.title} on StellarAid.`);
+  const socialLinks = {
+    x: `https://twitter.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`,
+    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
+    whatsapp: `https://wa.me/?text=${encodedText}%20${encodedUrl}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f0f4fa]">
+      <div className="border-b border-neutral-200 bg-white pt-24">
+        <div className="container mx-auto max-w-[1280px] px-4 py-5">
+          <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-neutral-500" aria-label="Breadcrumb">
+            <Link href="/" className="hover:text-primary-600">Home</Link>
+            <ChevronRight className="h-4 w-4 text-neutral-300" />
+            <Link href="/projects" className="hover:text-primary-600">Projects</Link>
+            <ChevronRight className="h-4 w-4 text-neutral-300" />
+            <span className="max-w-[260px] truncate text-neutral-900">{projectState.title}</span>
+          </nav>
+        </div>
+      </div>
+
+      <main className="container mx-auto max-w-[1280px] px-4 py-8 lg:py-12">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_390px]">
+          <div className="space-y-8">
+            <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
+              <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
+                <div className="max-w-3xl">
+                  <div className="mb-3 flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-secondary-50 px-3 py-1 text-xs font-bold uppercase text-secondary-700">
+                      {projectState.category || 'Community'}
+                    </span>
+                    {projectState.isVerified && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-primary-50 px-3 py-1 text-xs font-bold uppercase text-primary-700">
+                        <BadgeCheck className="h-3.5 w-3.5" />
+                        Verified
+                      </span>
+                    )}
+                    {projectState.isUrgent && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-danger-50 px-3 py-1 text-xs font-bold uppercase text-danger-700">
+                        <Zap className="h-3.5 w-3.5" />
+                        Urgent
+                      </span>
+                    )}
+                  </div>
+                  <h1 className="text-3xl font-extrabold tracking-tight text-neutral-900 md:text-5xl">
+                    {projectState.title}
+                  </h1>
+                  <p className="mt-4 text-base leading-7 text-neutral-600 md:text-lg">
+                    {projectState.summary || projectState.description}
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleNativeShare}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 bg-white text-neutral-600 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+                    aria-label="Share project"
+                  >
+                    <Share2 className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCopyLink}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 bg-white text-neutral-600 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+                    aria-label="Copy project link"
+                  >
+                    <Copy className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+
+              {images.length ? (
+                <ImageGallery images={images} />
+              ) : (
+                <div className="flex aspect-[16/9] items-center justify-center rounded-xl border border-neutral-200 bg-gradient-to-br from-primary-100 via-white to-secondary-100">
+                  <Sparkles className="h-12 w-12 text-primary-500" />
+                </div>
+              )}
+              {copied && <p className="mt-3 text-sm font-semibold text-success-700">Project link copied.</p>}
+            </section>
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+              <h2 className="text-2xl font-bold text-neutral-900">Campaign Story</h2>
+              <div className="mt-4 space-y-4 text-sm leading-7 text-neutral-700 md:text-base">
+                <p>{projectState.story || projectState.description}</p>
+                {projectState.impact && <p>{projectState.impact}</p>}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <h2 className="text-2xl font-bold text-neutral-900">Updates</h2>
+                <span className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-bold text-neutral-600">
+                  {updates.length} update{updates.length === 1 ? '' : 's'}
+                </span>
+              </div>
+              <div className="mt-6 space-y-5">
+                {updates.map((update) => (
+                  <article key={update.id} className="rounded-xl border border-neutral-200 bg-neutral-50 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <h3 className="text-lg font-semibold text-neutral-900">{update.title}</h3>
+                      <span className="text-sm font-medium text-neutral-500">{formatDate(update.createdAt)}</span>
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-neutral-700">{update.content}</p>
+                    {update.imageUrls?.length ? (
+                      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                        {update.imageUrls.slice(0, 2).map((url) => (
+                          <img
+                            key={url}
+                            src={url}
+                            alt={update.title}
+                            loading="lazy"
+                            className="h-44 w-full rounded-lg border border-neutral-200 object-cover"
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+              <h2 className="text-2xl font-bold text-neutral-900">Creator</h2>
+              <div className="mt-5 flex flex-col gap-5 sm:flex-row sm:items-start">
+                <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary-50 text-primary-600">
+                  {creator?.avatar ? (
+                    <img src={creator.avatar} alt={creator.name || 'Project creator'} className="h-full w-full object-cover" />
+                  ) : (
+                    <UserRound className="h-8 w-8" />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-lg font-bold text-neutral-900">{creator?.name || 'StellarAid Creator'}</h3>
+                    {(creator?.verified || projectState.isVerified) && (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-success-50 px-2.5 py-1 text-xs font-bold text-success-700">
+                        <ShieldCheck className="h-3.5 w-3.5" />
+                        Verified creator
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-neutral-600">
+                    {creator?.bio || 'This creator has submitted project documentation for StellarAid review.'}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-3 text-sm text-neutral-500">
+                    {creator?.location || projectState.location ? (
+                      <span className="inline-flex items-center gap-2">
+                        <MapPin className="h-4 w-4" />
+                        {creator?.location || projectState.location}
+                      </span>
+                    ) : null}
+                    {creator?.email ? (
+                      <a href={`mailto:${creator.email}`} className="inline-flex items-center gap-2 text-primary-600 hover:text-primary-700">
+                        <Mail className="h-4 w-4" />
+                        Contact creator
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <aside className="space-y-5 lg:sticky lg:top-24 lg:self-start">
+            <FundingProgress
+              currentAmount={currentAmount}
+              targetAmount={targetAmount}
+              donorCount={donorCount}
+              daysRemaining={daysRemaining}
+            />
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
+              <button
+                type="button"
+                onClick={() => setIsDonationOpen(true)}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary-600 px-5 py-3 text-base font-bold text-white shadow-stellar transition hover:bg-primary-700"
+              >
+                <Heart className="h-5 w-5" />
+                Donate Now
+              </button>
+
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div className="rounded-lg bg-neutral-50 p-3">
+                  <CalendarDays className="h-4 w-4 text-warning-500" />
+                  <p className="mt-2 font-bold text-neutral-900">
+                    {typeof daysRemaining === 'number' ? `${daysRemaining} days` : 'Open'}
+                  </p>
+                  <p className="text-xs text-neutral-500">Campaign window</p>
+                </div>
+                <div className="rounded-lg bg-neutral-50 p-3">
+                  <ExternalLink className="h-4 w-4 text-primary-500" />
+                  <p className="mt-2 font-bold text-neutral-900">{projectState.status || 'Active'}</p>
+                  <p className="text-xs text-neutral-500">Status</p>
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-neutral-200 bg-white p-5 shadow-sm">
+              <h2 className="text-sm font-bold uppercase text-neutral-500">Share Campaign</h2>
+              <div className="mt-4 grid grid-cols-4 gap-2">
+                {[
+                  { href: socialLinks.x, label: 'Share on X', icon: FaXTwitter },
+                  { href: socialLinks.facebook, label: 'Share on Facebook', icon: FaFacebookF },
+                  { href: socialLinks.whatsapp, label: 'Share on WhatsApp', icon: FaWhatsapp },
+                  { href: socialLinks.linkedin, label: 'Share on LinkedIn', icon: FaLinkedinIn },
+                ].map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <a
+                      key={item.label}
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex h-10 items-center justify-center rounded-lg border border-neutral-200 text-neutral-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-600"
+                      aria-label={item.label}
+                    >
+                      <Icon className="h-4 w-4" />
+                    </a>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className={clsx('rounded-xl border p-5 shadow-sm', projectState.isUrgent ? 'border-danger-200 bg-danger-50' : 'border-primary-100 bg-primary-50')}>
+              <h2 className={clsx('text-sm font-bold uppercase', projectState.isUrgent ? 'text-danger-700' : 'text-primary-700')}>
+                {projectState.isUrgent ? 'Urgent Need' : 'Verified Impact'}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-neutral-700">
+                {projectState.isUrgent
+                  ? 'This campaign has been marked urgent due to time-sensitive needs.'
+                  : 'Project information is reviewed so donors can support with confidence.'}
+              </p>
+            </section>
+          </aside>
+        </div>
+      </main>
+
+      <DonationModal
+        isOpen={isDonationOpen}
+        onClose={() => setIsDonationOpen(false)}
+        onSuccess={handleDonationSuccess}
+        project={{
+          id: projectState.id,
+          title: projectState.title,
+          imageUrl: projectState.imageUrl || images[0]?.src,
+        }}
+      />
+    </div>
+  );
+}
+
+export default ProjectDetailsClient;
+

--- a/lib/api/donations.ts
+++ b/lib/api/donations.ts
@@ -1,5 +1,10 @@
 import { apiClient } from './interceptors';
-import { Donation, ApiResponse, CreateDonationRequest } from '@/types/api';
+import {
+    Donation,
+    ApiResponse,
+    CreateDonationRequest,
+    SendDonationConfirmationEmailRequest,
+} from '@/types/api';
 
 export const donationsApi = {
     getDonations: async (projectId?: string): Promise<ApiResponse<Donation[]>> => {
@@ -10,6 +15,16 @@ export const donationsApi = {
 
     createDonation: async (data: CreateDonationRequest): Promise<ApiResponse<Donation>> => {
         const response = await apiClient.post<ApiResponse<Donation>>('/donations', data);
+        return response.data;
+    },
+
+    sendConfirmationEmail: async (
+        data: SendDonationConfirmationEmailRequest
+    ): Promise<ApiResponse<{ sent: boolean }>> => {
+        const response = await apiClient.post<ApiResponse<{ sent: boolean }>>(
+            '/donations/confirmation-email',
+            data
+        );
         return response.data;
     },
 

--- a/lib/stellar/explorer.ts
+++ b/lib/stellar/explorer.ts
@@ -1,0 +1,10 @@
+const DEFAULT_STELLAR_TX_EXPLORER = 'https://stellar.expert/explorer/testnet/tx';
+
+export function getStellarExplorerTxUrl(txHash: string) {
+  const baseUrl = (
+    process.env.NEXT_PUBLIC_STELLAR_EXPLORER_URL || DEFAULT_STELLAR_TX_EXPLORER
+  ).replace(/\/+$/, '');
+
+  return `${baseUrl}/${encodeURIComponent(txHash)}`;
+}
+

--- a/types/api.ts
+++ b/types/api.ts
@@ -39,6 +39,18 @@ export interface ChangeEmailRequest {
 }
 
 // Project Types
+export type ProjectStatus = "active" | "completed" | "almost-funded" | "paused" | "draft";
+
+export interface ProjectCreator {
+    id: string;
+    name?: string;
+    email?: string;
+    avatar?: string;
+    bio?: string;
+    location?: string;
+    verified?: boolean;
+}
+
 export interface Project {
     id: string;
     title: string;
@@ -47,6 +59,21 @@ export interface Project {
     currentAmount: string;
     creatorId: string;
     imageUrl?: string;
+    imageUrls?: string[];
+    category?: string;
+    status?: ProjectStatus;
+    isVerified?: boolean;
+    isUrgent?: boolean;
+    donorCount?: number;
+    donors?: number;
+    deadline?: string;
+    daysRemaining?: number;
+    location?: string;
+    summary?: string;
+    impact?: string;
+    story?: string;
+    creator?: ProjectCreator;
+    updates?: Update[];
     createdAt: string;
     updatedAt: string;
 }
@@ -64,6 +91,10 @@ export interface Donation {
     projectId: string;
     donorId: string;
     amount: string;
+    asset?: string;
+    message?: string;
+    status?: "CONFIRMED" | "PENDING" | "FAILED";
+    projectTitle?: string;
     txHash?: string;
     createdAt: string;
 }
@@ -72,6 +103,17 @@ export interface CreateDonationRequest {
     projectId: string;
     amount: string;
     txHash?: string;
+}
+
+export interface SendDonationConfirmationEmailRequest {
+    donationId?: string;
+    projectId: string;
+    projectTitle: string;
+    amount: string;
+    asset: string;
+    txHash: string;
+    donatedAt: string;
+    donorEmail?: string;
 }
 
 export interface Update {


### PR DESCRIPTION
…ge ```  Optional fuller version:  ```git feat: add donation success/failure flows and project details page  - add transaction success receipt modal with sharing, explorer link, and receipt download - add transaction failure modal with retry, support, and troubleshooting guidance - add responsive project details route with funding progress and creator info - extend project and donation API types ```

closed #99 
closed #100 
closed #101 
closed #102 