### PR TITLE
feat: resolve Stellar Wave issues #142 #143 #144 #146

### DIFF
--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+import dynamic from "next/dynamic";
 import {
   Search,
   Star,
   TrendingUp,
-  Clock,
   Zap,
   Heart,
   Users,
@@ -13,15 +13,34 @@ import {
 
 import { projectsApi } from "@/lib/api/projects";
 import { Project } from "@/types/api";
-import ProjectCard from "@/components/projects/ProjectCard";
-import {
-  ProjectFilters,
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+
+// Dynamic imports for heavy components to reduce initial bundle size (#142)
+const ProjectCard = dynamic(() => import("@/components/projects/ProjectCard"), {
+  loading: () => <ProjectCardSkeleton />,
+});
+
+const ProjectFilters = dynamic(
+  () =>
+    import("@/components/projects/ProjectFilters").then(
+      (m) => ({ default: m.ProjectFilters }),
+    ),
+  { ssr: false },
+);
+
+const ProjectSearch = dynamic(
+  () => import("@/components/projects/ProjectSearch"),
+  { ssr: false },
+);
+
+import type {
   ProjectFiltersState,
   SortOption,
 } from "@/components/projects/ProjectFilters";
-import ProjectSearch from "@/components/projects/ProjectSearch";
-import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { Pagination, type PageSize } from "@/components/ui/Pagination";
 
 // Types
 interface ProjectWithMetadata {
@@ -47,17 +66,8 @@ interface ProjectWithMetadata {
   updatedAt?: string;
 }
 
-interface ExplorePageState {
-  projects: ProjectWithMetadata[];
-  featuredProjects: ProjectWithMetadata[];
-  loading: boolean;
-  loadingMore: boolean;
-  error: string | null;
-  currentPage: number;
-  hasMore: boolean;
-  searchQuery: string;
-  filters: ProjectFiltersState;
-}
+// Total mock items (simulates a real API total count)
+const TOTAL_MOCK_ITEMS = 120;
 
 // Loading skeleton component
 const ProjectCardSkeleton = () => (
@@ -144,22 +154,39 @@ const FeaturedSection = ({ projects }: { projects: ProjectWithMetadata[] }) => (
 );
 
 export default function ExplorePage() {
-  const [state, setState] = useState<ExplorePageState>({
-    projects: [],
-    featuredProjects: [],
-    loading: true,
-    loadingMore: false,
-    error: null,
-    currentPage: 1,
-    hasMore: true,
-    searchQuery: "",
-    filters: {
-      sort: "newest",
-      verifiedOnly: false,
-      status: "all",
-      urgentOnly: false,
-    },
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // ── URL-driven pagination state (#146) ──────────────────────────────────────
+  const pageParam = Number(searchParams.get("page") ?? "1");
+  const sizeParam = Number(searchParams.get("size") ?? "12") as PageSize;
+  const validSizes: PageSize[] = [12, 24, 48];
+  const currentPage = Math.max(1, pageParam);
+  const pageSize: PageSize = validSizes.includes(sizeParam) ? sizeParam : 12;
+
+  const [projects, setProjects] = useState<ProjectWithMetadata[]>([]);
+  const [featuredProjects, setFeaturedProjects] = useState<ProjectWithMetadata[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [filters, setFilters] = useState<ProjectFiltersState>({
+    sort: "newest",
+    verifiedOnly: false,
+    status: "all",
+    urgentOnly: false,
   });
+
+  /** Push updated page/size to URL without full navigation */
+  const updateUrl = useCallback(
+    (page: number, size: PageSize) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("page", String(page));
+      params.set("size", String(size));
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams],
+  );
 
   // Mock data generator for demonstration
   const generateMockProject = useCallback(
@@ -191,9 +218,9 @@ export default function ExplorePage() {
       const target = Math.floor(Math.random() * 50000) + 10000;
       const current = Math.floor(Math.random() * target);
       const progress = Math.round((current / target) * 100);
-      const category = categories[index % categories.length] ?? 'Community';
-      const imageGradient = gradients[index % gradients.length] ?? gradients[0] ?? 'from-blue-400 to-purple-600';
-      const status = statuses[Math.floor(Math.random() * statuses.length)] ?? 'active';
+      const category = categories[index % categories.length] ?? "Community";
+      const imageGradient = gradients[index % gradients.length] ?? gradients[0] ?? "from-blue-400 to-purple-600";
+      const status = statuses[Math.floor(Math.random() * statuses.length)] ?? "active";
 
       return {
         id,
@@ -222,138 +249,96 @@ export default function ExplorePage() {
     [],
   );
 
-  // Fetch projects
+  // Fetch one page of projects
   const fetchProjects = useCallback(
-    async (page: number = 1, reset: boolean = false) => {
+    async (page: number, size: number) => {
       try {
-        setState((prev) => ({
-          ...prev,
-          loading: reset,
-          loadingMore: !reset && page > 1,
-          error: null,
-        }));
+        setLoading(true);
+        setError(null);
 
         // Simulate API delay
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 600));
 
-        // Generate mock data for demonstration
-        const newProjects = Array.from({ length: 9 }, (_, i) =>
-          generateMockProject(`project-${page}-${i}`, (page - 1) * 9 + i),
+        const newProjects = Array.from({ length: size }, (_, i) =>
+          generateMockProject(`project-${page}-${i}`, (page - 1) * size + i),
         );
 
-        setState((prev) => {
-          const projects = reset
-            ? newProjects
-            : [...prev.projects, ...newProjects];
-          return {
-            ...prev,
-            projects,
-            loading: false,
-            loadingMore: false,
-            currentPage: page,
-            hasMore: page < 5, // Simulate 5 pages of data
-          };
-        });
-      } catch (err) {
-        setState((prev) => ({
-          ...prev,
-          loading: false,
-          loadingMore: false,
-          error: "Failed to load projects. Please try again.",
-        }));
+        setProjects(newProjects);
+      } catch {
+        setError("Failed to load projects. Please try again.");
+      } finally {
+        setLoading(false);
       }
     },
     [generateMockProject],
   );
 
-  // Fetch featured projects
+  // Fetch featured projects (once)
   const fetchFeaturedProjects = useCallback(async () => {
     try {
-      // Generate featured projects (first 3 with featured flag)
       const featured = Array.from({ length: 3 }, (_, i) =>
         generateMockProject(`featured-${i}`, i),
       ).map((project) => ({ ...project, featured: true }));
-
-      setState((prev) => ({ ...prev, featuredProjects: featured }));
-    } catch (err) {
-      console.error("Failed to fetch featured projects:", err);
+      setFeaturedProjects(featured);
+    } catch {
+      console.error("Failed to fetch featured projects");
     }
   }, [generateMockProject]);
 
-  // Initial load
+  // Re-fetch whenever page or pageSize changes
   useEffect(() => {
-    fetchProjects(1, true);
+    fetchProjects(currentPage, pageSize);
+  }, [fetchProjects, currentPage, pageSize]);
+
+  useEffect(() => {
     fetchFeaturedProjects();
-  }, [fetchProjects, fetchFeaturedProjects]);
+  }, [fetchFeaturedProjects]);
 
   // Handle search
   const handleSearch = useCallback(
     (query: string) => {
-      setState((prev) => ({ ...prev, searchQuery: query, currentPage: 1 }));
-      fetchProjects(1, true);
+      setSearchQuery(query);
+      updateUrl(1, pageSize);
     },
-    [fetchProjects],
+    [updateUrl, pageSize],
   );
 
   // Handle filters change
   const handleFiltersChange = useCallback(
-    (filters: ProjectFiltersState) => {
-      setState((prev) => ({ ...prev, filters, currentPage: 1 }));
-      fetchProjects(1, true);
+    (newFilters: ProjectFiltersState) => {
+      setFilters(newFilters);
+      updateUrl(1, pageSize);
     },
-    [fetchProjects],
+    [updateUrl, pageSize],
   );
 
-  // Load more projects
-  const loadMore = useCallback(() => {
-    if (!state.loadingMore && state.hasMore) {
-      fetchProjects(state.currentPage + 1, false);
-    }
-  }, [state.loadingMore, state.hasMore, state.currentPage, fetchProjects]);
-
-  // Filter and sort projects
+  // Filter and sort projects (client-side within the current page)
   const filteredProjects = useMemo(() => {
-    let filtered = state.projects;
+    let filtered = projects;
 
-    // Apply search filter
-    if (state.searchQuery) {
+    if (searchQuery) {
       filtered = filtered.filter(
         (project) =>
-          project.title
-            .toLowerCase()
-            .includes(state.searchQuery.toLowerCase()) ||
+          project.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
           (project.description &&
-            project.description
-              .toLowerCase()
-              .includes(state.searchQuery.toLowerCase())),
+            project.description.toLowerCase().includes(searchQuery.toLowerCase())),
       );
     }
 
-    // Apply status filter
-    if (state.filters.status !== "all") {
-      filtered = filtered.filter(
-        (project) => project.status === state.filters.status,
-      );
+    if (filters.status !== "all") {
+      filtered = filtered.filter((project) => project.status === filters.status);
     }
-
-    // Apply verified filter
-    if (state.filters.verifiedOnly) {
+    if (filters.verifiedOnly) {
       filtered = filtered.filter((project) => project.isVerified);
     }
-
-    // Apply urgent filter
-    if (state.filters.urgentOnly) {
+    if (filters.urgentOnly) {
       filtered = filtered.filter((project) => project.isUrgent);
     }
 
-    // Apply sorting
     filtered.sort((a, b) => {
-      switch (state.filters.sort) {
+      switch (filters.sort) {
         case "newest":
-          return (
-            new Date(b.createdAt || "").getTime() -
-            new Date(a.createdAt || "").getTime()
-          );
+          return new Date(b.createdAt || "").getTime() - new Date(a.createdAt || "").getTime();
         case "most-funded":
           return (b.raised || 0) - (a.raised || 0);
         case "ending-soon":
@@ -366,7 +351,7 @@ export default function ExplorePage() {
     });
 
     return filtered;
-  }, [state.projects, state.searchQuery, state.filters]);
+  }, [projects, searchQuery, filters]);
 
   return (
     <div className="min-h-screen bg-[#f0f4fa]">
@@ -397,7 +382,7 @@ export default function ExplorePage() {
               <div className="flex items-center justify-center gap-2 mb-1">
                 <TrendingUp className="w-4 h-4 text-primary-500" />
                 <span className="text-2xl font-bold text-neutral-900">
-                  {filteredProjects.length}
+                  {TOTAL_MOCK_ITEMS}
                 </span>
               </div>
               <span className="text-sm text-neutral-600">Active Campaigns</span>
@@ -441,39 +426,39 @@ export default function ExplorePage() {
       {/* Main Content */}
       <div className="container mx-auto px-4 max-w-[1280px] py-8">
         {/* Featured Projects */}
-        {state.featuredProjects.length > 0 &&
-          !state.searchQuery &&
-          state.filters.status === "all" && (
-            <FeaturedSection projects={state.featuredProjects} />
+        {featuredProjects.length > 0 &&
+          !searchQuery &&
+          filters.status === "all" &&
+          currentPage === 1 && (
+            <FeaturedSection projects={featuredProjects} />
           )}
 
         {/* All Projects */}
         <section>
           <div className="flex items-center justify-between mb-6">
             <h2 className="text-2xl font-bold text-neutral-900">
-              {state.searchQuery
+              {searchQuery
                 ? `Search Results (${filteredProjects.length})`
                 : "All Campaigns"}
             </h2>
             {filteredProjects.length > 0 && (
               <span className="text-sm text-neutral-500">
-                Showing {filteredProjects.length} campaign
-                {filteredProjects.length !== 1 ? "s" : ""}
+                Page {currentPage} · {filteredProjects.length} shown
               </span>
             )}
           </div>
 
           {/* Loading State */}
-          {state.loading && (
+          {loading && (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {Array.from({ length: 9 }, (_, i) => (
+              {Array.from({ length: pageSize }, (_, i) => (
                 <ProjectCardSkeleton key={i} />
               ))}
             </div>
           )}
 
           {/* Error State */}
-          {state.error && (
+          {error && (
             <Card variant="elevated" className="p-8 text-center">
               <div className="w-16 h-16 bg-danger-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Search className="w-8 h-8 text-danger-600" />
@@ -481,19 +466,18 @@ export default function ExplorePage() {
               <h3 className="text-xl font-bold text-neutral-900 mb-2">
                 Something went wrong
               </h3>
-              <p className="text-neutral-600 mb-4">{state.error}</p>
-              <Button onClick={() => fetchProjects(1, true)}>Try Again</Button>
+              <p className="text-neutral-600 mb-4">{error}</p>
+              <Button onClick={() => fetchProjects(currentPage, pageSize)}>
+                Try Again
+              </Button>
             </Card>
           )}
 
           {/* Projects Grid */}
-          {!state.loading && !state.error && (
+          {!loading && !error && (
             <>
               {filteredProjects.length === 0 ? (
-                <EmptyState
-                  searchQuery={state.searchQuery}
-                  filters={state.filters}
-                />
+                <EmptyState searchQuery={searchQuery} filters={filters} />
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {filteredProjects.map((project) => (
@@ -504,35 +488,21 @@ export default function ExplorePage() {
             </>
           )}
 
-          {/* Load More */}
-          {!state.loading &&
-            !state.error &&
-            filteredProjects.length > 0 &&
-            state.hasMore && (
-              <div className="text-center mt-12">
-                <Button
-                  variant="secondary"
-                  size="lg"
-                  onClick={loadMore}
-                  isLoading={state.loadingMore}
-                  disabled={state.loadingMore}
-                >
-                  {state.loadingMore ? "Loading..." : "Load More Campaigns"}
-                </Button>
-              </div>
-            )}
-
-          {/* End of Results */}
-          {!state.loading &&
-            !state.error &&
-            filteredProjects.length > 0 &&
-            !state.hasMore && (
-              <div className="text-center mt-12 py-8 border-t border-neutral-200">
-                <p className="text-neutral-500">
-                  You&apos;ve reached the end of the campaign list.
-                </p>
-              </div>
-            )}
+          {/* Pagination controls (#146) */}
+          {!loading && !error && filteredProjects.length > 0 && (
+            <div className="mt-10">
+              <Pagination
+                page={currentPage}
+                pageSize={pageSize}
+                total={TOTAL_MOCK_ITEMS}
+                onPageChange={(p) => {
+                  updateUrl(p, pageSize);
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                }}
+                onPageSizeChange={(s) => updateUrl(1, s)}
+              />
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import NextAuthProvider from "@/components/NextAuthProvider";
 import UserDataSync from "@/components/UserDataSync";
 import Script from "next/script";
 import CookieConsent from "@/components/CookieConsent";
+import { KeyboardShortcutsProvider } from "@/components/KeyboardShortcutsProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -138,9 +139,11 @@ export default function RootLayout({
             <NextAuthProvider>
               <UserDataSync />
               <ToastProvider position="top-right" maxToasts={5}>
-                <GlobalLoadingOverlay />
-                <Suspense fallback={<GlobalLoading message="Loading..." />}>{children}</Suspense>
-                <CookieConsent />
+                <KeyboardShortcutsProvider>
+                  <GlobalLoadingOverlay />
+                  <Suspense fallback={<GlobalLoading message="Loading..." />}>{children}</Suspense>
+                  <CookieConsent />
+                </KeyboardShortcutsProvider>
               </ToastProvider>
             </NextAuthProvider>
           </ErrorBoundaryProvider>

--- a/components/KeyboardShortcutsProvider.tsx
+++ b/components/KeyboardShortcutsProvider.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+/**
+ * KeyboardShortcutsProvider — mounts global keyboard shortcuts for power users (#144).
+ * Wrap this around the app in the root layout.
+ */
+
+import React, { useState } from 'react';
+import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
+import { KeyboardShortcutsHelp } from '@/components/ui/KeyboardShortcutsHelp';
+
+export function KeyboardShortcutsProvider({ children }: { children: React.ReactNode }) {
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  useKeyboardShortcuts({ onToggleHelp: () => setHelpOpen((v) => !v) });
+
+  return (
+    <>
+      {children}
+      <KeyboardShortcutsHelp isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
+    </>
+  );
+}

--- a/components/donations/TransactionErrorModal.tsx
+++ b/components/donations/TransactionErrorModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useRef } from 'react';
+import { parseStellarError } from '@/lib/stellar/errorHandler';
 import {
   AlertTriangle,
   Clock,
@@ -151,6 +152,12 @@ function extractMessage(error: unknown) {
 }
 
 export function classifyTransactionError(error: unknown): TransactionFailureType {
+  // Use the Stellar error handler for richer code-based classification (#143)
+  const parsed = parseStellarError(error);
+  if (parsed.code === 'USER_REJECTED') return 'rejected';
+  if (parsed.code === 'INSUFFICIENT_FUNDS' || parsed.code === 'LOW_RESERVE') return 'insufficient_balance';
+  if (parsed.code === 'NETWORK_ERROR') return 'network';
+
   const message = extractMessage(error).toLowerCase();
 
   if (message.includes('insufficient') || message.includes('balance') || message.includes('reserve')) {

--- a/components/projects/ProjectSearch.tsx
+++ b/components/projects/ProjectSearch.tsx
@@ -52,6 +52,7 @@ export const ProjectSearch: React.FC<ProjectSearchProps> = ({
         value={inputValue}
         onChange={handleChange}
         placeholder={placeholder}
+        data-search-input
         className="w-full pl-10 pr-10 py-2.5 border border-neutral-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all duration-200 bg-white"
       />
       {inputValue && (

--- a/components/ui/KeyboardShortcutsHelp.tsx
+++ b/components/ui/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+/**
+ * KeyboardShortcutsHelp — modal overlay listing all keyboard shortcuts (#144)
+ */
+
+import React from 'react';
+import { Keyboard, X } from 'lucide-react';
+import { SHORTCUT_DEFINITIONS } from '@/hooks/useKeyboardShortcuts';
+
+interface KeyboardShortcutsHelpProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex items-center rounded border border-neutral-300 bg-neutral-100 px-1.5 py-0.5 font-mono text-xs text-neutral-700 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300">
+      {children}
+    </kbd>
+  );
+}
+
+export function KeyboardShortcutsHelp({ isOpen, onClose }: KeyboardShortcutsHelpProps) {
+  if (!isOpen) return null;
+
+  // Group shortcuts by category
+  const grouped = SHORTCUT_DEFINITIONS.reduce<Record<string, typeof SHORTCUT_DEFINITIONS>>(
+    (acc, s) => {
+      (acc[s.category] ??= []).push(s);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    /* Backdrop */
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shortcuts-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white shadow-2xl dark:bg-neutral-900">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-neutral-200 px-6 py-4 dark:border-neutral-700">
+          <div className="flex items-center gap-2">
+            <Keyboard className="h-5 w-5 text-primary-500" />
+            <h2 id="shortcuts-title" className="text-base font-semibold text-neutral-900 dark:text-white">
+              Keyboard Shortcuts
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-lg p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-700 dark:hover:bg-neutral-800"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="divide-y divide-neutral-100 px-6 py-4 dark:divide-neutral-800">
+          {Object.entries(grouped).map(([category, shortcuts]) => (
+            <div key={category} className="py-3 first:pt-0 last:pb-0">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-400">
+                {category}
+              </p>
+              <ul className="space-y-2">
+                {shortcuts.map((s) => (
+                  <li key={s.keys} className="flex items-center justify-between gap-4">
+                    <span className="text-sm text-neutral-700 dark:text-neutral-300">
+                      {s.description}
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1">
+                      {s.keys.split(' ').map((k, i) => (
+                        <React.Fragment key={k}>
+                          {i > 0 && (
+                            <span className="text-xs text-neutral-400">then</span>
+                          )}
+                          <Kbd>{k}</Kbd>
+                        </React.Fragment>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer hint */}
+        <div className="border-t border-neutral-200 px-6 py-3 dark:border-neutral-700">
+          <p className="text-center text-xs text-neutral-400">
+            Press <Kbd>?</Kbd> to toggle this panel · <Kbd>Esc</Kbd> to close
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default KeyboardShortcutsHelp;

--- a/components/ui/Pagination.tsx
+++ b/components/ui/Pagination.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+/**
+ * Pagination — server-side pagination controls (#146)
+ *
+ * Features:
+ *  - Page size selector (12 / 24 / 48 per page)
+ *  - Previous / Next navigation
+ *  - Page number buttons with ellipsis
+ *  - Total count display
+ *  - Keyboard navigation (← / →)
+ *  - URL query params: ?page=2&size=24
+ */
+
+import React, { useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+export const PAGE_SIZE_OPTIONS = [12, 24, 48] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+export interface PaginationProps {
+  /** Current 1-based page number */
+  page: number;
+  /** Number of items per page */
+  pageSize: PageSize;
+  /** Total number of items across all pages */
+  total: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: PageSize) => void;
+  /** Whether to listen for ← / → keyboard navigation */
+  enableKeyboard?: boolean;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Returns an array of page numbers / ellipsis markers to render */
+function buildPageRange(current: number, total: number): (number | '…')[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+  const pages: (number | '…')[] = [1];
+
+  if (current > 3) pages.push('…');
+
+  const start = clamp(current - 1, 2, total - 1);
+  const end = clamp(current + 1, 2, total - 1);
+
+  for (let i = start; i <= end; i++) pages.push(i);
+
+  if (current < total - 2) pages.push('…');
+
+  pages.push(total);
+  return pages;
+}
+
+export function Pagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onPageSizeChange,
+  enableKeyboard = true,
+}: PaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  const goTo = useCallback(
+    (p: number) => onPageChange(clamp(p, 1, totalPages)),
+    [onPageChange, totalPages],
+  );
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!enableKeyboard) return;
+
+    function handleKey(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+
+      if (e.key === 'ArrowLeft') goTo(page - 1);
+      else if (e.key === 'ArrowRight') goTo(page + 1);
+    }
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [enableKeyboard, page, goTo]);
+
+  const pageRange = buildPageRange(page, totalPages);
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between"
+    >
+      {/* Total count */}
+      <p className="text-sm text-neutral-500">
+        {total === 0 ? (
+          'No results'
+        ) : (
+          <>
+            Showing <span className="font-medium text-neutral-900">{from}–{to}</span> of{' '}
+            <span className="font-medium text-neutral-900">{total}</span> campaigns
+          </>
+        )}
+      </p>
+
+      <div className="flex items-center gap-3">
+        {/* Page size selector */}
+        <div className="flex items-center gap-2 text-sm text-neutral-600">
+          <label htmlFor="page-size-select" className="whitespace-nowrap">
+            Per page:
+          </label>
+          <select
+            id="page-size-select"
+            value={pageSize}
+            onChange={(e) => {
+              onPageSizeChange(Number(e.target.value) as PageSize);
+              onPageChange(1);
+            }}
+            className="rounded-lg border border-neutral-200 bg-white px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            {PAGE_SIZE_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Prev / page numbers / Next */}
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Previous page"
+            disabled={page <= 1}
+            onClick={() => goTo(page - 1)}
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-neutral-200 text-neutral-600 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+
+          {pageRange.map((item, idx) =>
+            item === '…' ? (
+              <span
+                key={`ellipsis-${idx}`}
+                className="flex h-8 w-8 items-center justify-center text-sm text-neutral-400"
+              >
+                …
+              </span>
+            ) : (
+              <button
+                key={item}
+                type="button"
+                aria-label={`Page ${item}`}
+                aria-current={item === page ? 'page' : undefined}
+                onClick={() => goTo(item)}
+                className={`flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition
+                  ${item === page
+                    ? 'bg-primary-600 text-white shadow-sm'
+                    : 'border border-neutral-200 text-neutral-700 hover:bg-neutral-100'
+                  }`}
+              >
+                {item}
+              </button>
+            ),
+          )}
+
+          <button
+            type="button"
+            aria-label="Next page"
+            disabled={page >= totalPages}
+            onClick={() => goTo(page + 1)}
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-neutral-200 text-neutral-600 transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,137 @@
+'use client';
+
+/**
+ * useKeyboardShortcuts — global keyboard shortcuts for power users (#144)
+ *
+ * Shortcuts:
+ *   /          → focus the search bar (element with data-search-input)
+ *   Escape     → close the topmost open modal/dialog
+ *   ?          → toggle the shortcuts help overlay
+ *   g p        → navigate to /explore (Projects)
+ *   g d        → navigate to /dashboard
+ */
+
+import { useEffect, useCallback, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+
+export interface ShortcutDefinition {
+  keys: string;
+  description: string;
+  category: string;
+}
+
+export const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  { keys: '/', description: 'Focus search bar', category: 'Navigation' },
+  { keys: 'Escape', description: 'Close modal / dialog', category: 'Navigation' },
+  { keys: '?', description: 'Show keyboard shortcuts', category: 'Help' },
+  { keys: 'g p', description: 'Go to Projects', category: 'Navigation' },
+  { keys: 'g d', description: 'Go to Dashboard', category: 'Navigation' },
+];
+
+interface UseKeyboardShortcutsOptions {
+  /** Called when the user presses "?" to toggle the help overlay */
+  onToggleHelp?: () => void;
+}
+
+export function useKeyboardShortcuts({ onToggleHelp }: UseKeyboardShortcutsOptions = {}) {
+  const router = useRouter();
+  // Track the first key of a two-key sequence (e.g. "g")
+  const pendingKeyRef = useRef<string | null>(null);
+  const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPending = useCallback(() => {
+    pendingKeyRef.current = null;
+    if (pendingTimerRef.current) {
+      clearTimeout(pendingTimerRef.current);
+      pendingTimerRef.current = null;
+    }
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const tag = target.tagName.toLowerCase();
+
+      // Ignore shortcuts when typing in inputs/textareas/contenteditable
+      const isTyping =
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        target.isContentEditable;
+
+      // "/" and "?" are allowed even in inputs only if we explicitly want them
+      const isSlash = e.key === '/';
+      const isQuestion = e.key === '?';
+      const isEscape = e.key === 'Escape';
+
+      if (isTyping && !isEscape) {
+        clearPending();
+        return;
+      }
+
+      // ── Escape: close topmost modal/dialog ──────────────────────────────────
+      if (isEscape) {
+        clearPending();
+        // Let the browser/React handle Escape natively for dialogs first.
+        // We only act if no modal is currently focused.
+        const openDialog = document.querySelector<HTMLElement>(
+          '[role="dialog"][aria-modal="true"]',
+        );
+        if (openDialog) {
+          const closeBtn = openDialog.querySelector<HTMLElement>(
+            '[aria-label="Close"], [data-close-modal], button[type="button"]:last-of-type',
+          );
+          closeBtn?.click();
+        }
+        return;
+      }
+
+      // ── "/" : focus search input ─────────────────────────────────────────────
+      if (isSlash && !isTyping) {
+        e.preventDefault();
+        clearPending();
+        const searchInput = document.querySelector<HTMLElement>(
+          '[data-search-input], input[type="search"], input[placeholder*="earch"]',
+        );
+        searchInput?.focus();
+        return;
+      }
+
+      // ── "?" : toggle help overlay ────────────────────────────────────────────
+      if (isQuestion && !isTyping) {
+        e.preventDefault();
+        clearPending();
+        onToggleHelp?.();
+        return;
+      }
+
+      // ── Two-key sequences (g + …) ────────────────────────────────────────────
+      if (pendingKeyRef.current === 'g') {
+        clearPending();
+        if (e.key === 'p') {
+          e.preventDefault();
+          router.push('/explore');
+        } else if (e.key === 'd') {
+          e.preventDefault();
+          router.push('/dashboard');
+        }
+        return;
+      }
+
+      if (e.key === 'g' && !isTyping) {
+        pendingKeyRef.current = 'g';
+        // Reset after 1 s if no second key arrives
+        pendingTimerRef.current = setTimeout(clearPending, 1000);
+      }
+    },
+    [router, onToggleHelp, clearPending],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      clearPending();
+    };
+  }, [handleKeyDown, clearPending]);
+}

--- a/lib/stellar/errorHandler.ts
+++ b/lib/stellar/errorHandler.ts
@@ -1,0 +1,200 @@
+/**
+ * Stellar / Web3 Transaction Error Handler (#143)
+ *
+ * Maps raw Stellar SDK and JSON-RPC error codes to user-friendly messages.
+ */
+
+export interface StellarTxError {
+  /** Short machine-readable code */
+  code: string;
+  /** Human-readable message shown to the user */
+  message: string;
+  /** Whether the user can retry the operation */
+  retryable: boolean;
+}
+
+// ─── Error code maps ──────────────────────────────────────────────────────────
+
+const JSON_RPC_ERRORS: Record<number, StellarTxError> = {
+  4001: {
+    code: "USER_REJECTED",
+    message: "You rejected the transaction. No funds were moved.",
+    retryable: true,
+  },
+  "-32603": {
+    code: "INTERNAL_RPC_ERROR",
+    message: "An internal wallet error occurred. Please try again.",
+    retryable: true,
+  },
+} as unknown as Record<number, StellarTxError>;
+
+const STRING_CODE_ERRORS: Record<string, StellarTxError> = {
+  // Wallet / user errors
+  USER_REJECTED: {
+    code: "USER_REJECTED",
+    message: "You rejected the transaction. No funds were moved.",
+    retryable: true,
+  },
+
+  // Stellar Horizon result codes
+  op_underfunded: {
+    code: "INSUFFICIENT_FUNDS",
+    message: "Insufficient funds to complete this transaction.",
+    retryable: false,
+  },
+  op_low_reserve: {
+    code: "LOW_RESERVE",
+    message:
+      "Your account balance is below the minimum reserve required by Stellar.",
+    retryable: false,
+  },
+  op_no_destination: {
+    code: "NO_DESTINATION",
+    message: "The destination account does not exist on the Stellar network.",
+    retryable: false,
+  },
+  op_no_trust: {
+    code: "NO_TRUST",
+    message:
+      "The destination account has not established a trustline for this asset.",
+    retryable: false,
+  },
+  op_not_authorized: {
+    code: "NOT_AUTHORIZED",
+    message: "This account is not authorized to send this asset.",
+    retryable: false,
+  },
+  tx_bad_seq: {
+    code: "BAD_SEQUENCE",
+    message: "Transaction sequence number mismatch. Please try again.",
+    retryable: true,
+  },
+  tx_insufficient_fee: {
+    code: "INSUFFICIENT_FEE",
+    message: "The transaction fee is too low. Please increase the fee.",
+    retryable: true,
+  },
+  tx_too_late: {
+    code: "TX_TOO_LATE",
+    message: "The transaction expired before it could be submitted.",
+    retryable: true,
+  },
+  tx_no_account: {
+    code: "NO_ACCOUNT",
+    message: "The source account does not exist on the Stellar network.",
+    retryable: false,
+  },
+
+  // Network / RPC errors
+  NETWORK_ERROR: {
+    code: "NETWORK_ERROR",
+    message: "Network connection failed. Check your internet and try again.",
+    retryable: true,
+  },
+  UNPREDICTABLE_GAS_LIMIT: {
+    code: "CONTRACT_REVERT",
+    message: "The transaction would fail on-chain. Please review the details.",
+    retryable: false,
+  },
+  INSUFFICIENT_FUNDS: {
+    code: "INSUFFICIENT_FUNDS",
+    message: "Insufficient funds to complete this transaction.",
+    retryable: false,
+  },
+
+  // Freighter / Albedo wallet errors
+  "User declined access": {
+    code: "USER_REJECTED",
+    message: "Wallet access was denied. Please approve the connection request.",
+    retryable: true,
+  },
+  "Transaction was rejected": {
+    code: "USER_REJECTED",
+    message: "You rejected the transaction. No funds were moved.",
+    retryable: true,
+  },
+};
+
+// ─── Main parser ──────────────────────────────────────────────────────────────
+
+/**
+ * Parse any Stellar / Web3 error into a structured, user-friendly object.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await submitTransaction(tx);
+ * } catch (err) {
+ *   const parsed = parseStellarError(err);
+ *   toast.error(parsed.message);
+ * }
+ * ```
+ */
+export function parseStellarError(error: unknown): StellarTxError {
+  if (!error) {
+    return {
+      code: "UNKNOWN_ERROR",
+      message: "An unexpected error occurred. Please try again.",
+      retryable: true,
+    };
+  }
+
+  // JSON-RPC numeric code (e.g. MetaMask / WalletConnect style)
+  if (typeof error === "object" && error !== null) {
+    const err = error as Record<string, unknown>;
+
+    // Numeric code
+    if (typeof err.code === "number" && JSON_RPC_ERRORS[err.code]) {
+      return JSON_RPC_ERRORS[err.code]!;
+    }
+
+    // Stellar Horizon extras.result_codes
+    const extras = err.response as Record<string, unknown> | undefined;
+    const resultCodes = extras?.data as
+      | { extras?: { result_codes?: { operations?: string[]; transaction?: string } } }
+      | undefined;
+    const opCodes = resultCodes?.extras?.result_codes?.operations ?? [];
+    const txCode = resultCodes?.extras?.result_codes?.transaction ?? "";
+
+    for (const code of opCodes) {
+      if (STRING_CODE_ERRORS[code]) return STRING_CODE_ERRORS[code]!;
+    }
+    if (txCode && STRING_CODE_ERRORS[txCode]) {
+      return STRING_CODE_ERRORS[txCode]!;
+    }
+
+    // String code property
+    if (typeof err.code === "string" && STRING_CODE_ERRORS[err.code]) {
+      return STRING_CODE_ERRORS[err.code]!;
+    }
+
+    // Message-based matching
+    const message =
+      typeof err.message === "string" ? err.message : String(error);
+    for (const [key, val] of Object.entries(STRING_CODE_ERRORS)) {
+      if (message.toLowerCase().includes(key.toLowerCase())) return val;
+    }
+
+    // Fallback with original message
+    if (typeof err.message === "string") {
+      return {
+        code: "TRANSACTION_FAILED",
+        message: err.message,
+        retryable: false,
+      };
+    }
+  }
+
+  return {
+    code: "UNKNOWN_ERROR",
+    message: "An unexpected error occurred. Please try again.",
+    retryable: true,
+  };
+}
+
+/**
+ * Returns true when the error is simply the user declining the transaction.
+ */
+export function isUserRejection(error: unknown): boolean {
+  return parseStellarError(error).code === "USER_REJECTED";
+}

--- a/lib/stellar/index.ts
+++ b/lib/stellar/index.ts
@@ -77,3 +77,7 @@ export {
   getServerHealth,
   isConnectionAvailable,
 } from './connection';
+
+// Error handling exports (#143)
+export type { StellarTxError } from './errorHandler';
+export { parseStellarError, isUserRejection } from './errorHandler';


### PR DESCRIPTION
## Summary

Resolves all four Stellar Wave issues in a single PR.

---

### #142 — Reduce initial JS bundle size

- Added  imports for `ProjectCard`, `ProjectFilters`, and `ProjectSearch` in `app/explore/page.tsx`
- These components pull in heavy dependencies (recharts, framer-motion, Stellar SDK); lazy-loading them splits them out of the initial bundle

---

### #143 — Comprehensive error handling for Web3/Stellar transactions

- New `lib/stellar/errorHandler.ts` — `parseStellarError(error)` maps Stellar Horizon result codes (`op_underfunded`, `tx_bad_seq`, …), JSON-RPC codes (4001, -32603), and wallet messages (Freighter/Albedo) to structured `StellarTxError` objects with user-friendly messages and a `retryable` flag
- `classifyTransactionError` in `TransactionErrorModal` now calls `parseStellarError` first for code-based classification before falling back to message matching
- Exported from `lib/stellar/index.ts`

---

### #144 — Keyboard shortcuts for power users

| Shortcut | Action |
|---|---|
| `/` | Focus search bar |
| `Escape` | Close open modal |
| `?` | Toggle shortcuts help overlay |
| `g` `p` | Go to Projects (/explore) |
| `g` `d` | Go to Dashboard |

- `hooks/useKeyboardShortcuts.ts` — hook with two-key sequence support
- `components/ui/KeyboardShortcutsHelp.tsx` — accessible modal overlay listing all shortcuts
- `components/KeyboardShortcutsProvider.tsx` — client wrapper mounted in root layout
- `data-search-input` attribute added to `ProjectSearch` input for `/` shortcut targeting

---

### #146 — Pagination for project listings

- New `components/ui/Pagination.tsx` — page-size selector (12/24/48), prev/next buttons, page number range with ellipsis, total count display, keyboard ← / → navigation
- URL query params: `?page=2&size=24` — shareable, browser-back-compatible
- Replaces the previous infinite-scroll "Load More" pattern in `app/explore/page.tsx`

---

Closes #142
Closes #143
Closes #144
Closes #146