### PR TITLE
feat: add React Query provider and query keys factory

### DIFF
--- a/components/ReactQueryProvider.tsx
+++ b/components/ReactQueryProvider.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState, type ReactNode } from 'react';
+
+export default function ReactQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000, // 1 minute
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,0 +1,22 @@
+/**
+ * Query keys factory — centralised, typed keys for React Query.
+ * Import and use these instead of inline string arrays.
+ */
+export const queryKeys = {
+  projects: {
+    all: ['projects'] as const,
+    list: (filters?: Record<string, unknown>) =>
+      ['projects', 'list', filters] as const,
+    detail: (id: string) => ['projects', 'detail', id] as const,
+  },
+  campaigns: {
+    all: ['campaigns'] as const,
+    list: () => ['campaigns', 'list'] as const,
+    detail: (id: string) => ['campaigns', 'detail', id] as const,
+  },
+  user: {
+    all: ['user'] as const,
+    profile: (address: string) => ['user', 'profile', address] as const,
+    donations: (address: string) => ['user', 'donations', address] as const,
+  },
+} as const;


### PR DESCRIPTION
## Summary
- lib/queryKeys.ts — centralised typed query keys factory for projects, campaigns, and user queries
- components/ReactQueryProvider.tsx — QueryClientProvider with staleTime: 60s, etry: 1, and ReactQueryDevtools in dev

closes #155