### PR TITLE
feat(campaigns): add campaigns listing page and useCampaigns hook

### DIFF
--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Inbox } from 'lucide-react';
+import { Pagination, PageSize } from '@/components/ui/Pagination';
+import { ProjectCard } from '@/components/projects/ProjectCard';
+import { ProjectFilters } from '@/components/projects/ProjectFilters';
+import useCampaigns from '@/hooks/useCampaigns';
+
+export default function CampaignsPage() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<PageSize>(12);
+
+  const { data, isLoading, isError } = useCampaigns(page, pageSize);
+  const campaigns = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="relative bg-white pt-20 pb-8">
+        <div className="container mx-auto px-4 max-w-[1280px]">
+          <h1 className="text-4xl font-extrabold text-foreground mb-2">All Campaigns</h1>
+          <p className="text-neutral-500">Browse active campaigns you can support.</p>
+        </div>
+      </div>
+
+      <ProjectFilters />
+
+      <main className="container mx-auto px-4 py-10 max-w-[1280px]">
+        <div className="flex items-center justify-between mb-6">
+          <p className="text-sm text-neutral-600">Total campaigns: <span className="font-semibold text-foreground">{total}</span></p>
+          <div />
+        </div>
+
+        {isError && (
+          <div className="py-12 text-center text-muted-foreground">Could not load campaigns. Please try again later.</div>
+        )}
+
+        {!isLoading && campaigns.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-24 bg-white rounded-3xl border border-dashed border-neutral-300">
+            <div className="w-20 h-20 bg-neutral-50 rounded-full flex items-center justify-center mb-6">
+              <Inbox className="w-10 h-10 text-neutral-300" />
+            </div>
+            <h3 className="text-2xl font-bold text-neutral-900 mb-2">No campaigns found</h3>
+            <p className="text-neutral-500 text-center max-w-sm mb-8">There are no active campaigns right now. Check back later or explore featured campaigns.</p>
+            <Link href="/" className="px-5 py-2 rounded-lg border border-neutral-200 text-sm font-bold">Return Home</Link>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+              {campaigns.map((c) => (
+                <ProjectCard key={c.id} project={c as any} />
+              ))}
+            </div>
+
+            <div className="mt-8">
+              <Pagination
+                page={page}
+                pageSize={pageSize}
+                total={total}
+                onPageChange={(p) => setPage(p)}
+                onPageSizeChange={(s) => {
+                  setPageSize(s);
+                  setPage(1);
+                }}
+              />
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Inbox } from 'lucide-react';
 import { Pagination, PageSize } from '@/components/ui/Pagination';
@@ -11,10 +11,23 @@ import useCampaigns from '@/hooks/useCampaigns';
 export default function CampaignsPage() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<PageSize>(12);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [debouncedTerm, setDebouncedTerm] = useState('');
 
-  const { data, isLoading, isError } = useCampaigns(page, pageSize);
+  const { data, isLoading, isError } = useCampaigns(page, pageSize, debouncedTerm);
   const campaigns = data?.items ?? [];
   const total = data?.total ?? 0;
+
+  // debounce input (300ms)
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedTerm(searchTerm), 300);
+    return () => clearTimeout(t);
+  }, [searchTerm]);
+
+  // reset to first page when search changes
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedTerm]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -28,8 +41,18 @@ export default function CampaignsPage() {
       <ProjectFilters />
 
       <main className="container mx-auto px-4 py-10 max-w-[1280px]">
-        <div className="flex items-center justify-between mb-6">
-          <p className="text-sm text-neutral-600">Total campaigns: <span className="font-semibold text-foreground">{total}</span></p>
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+          <div className="flex items-center gap-4 w-full">
+            <input
+              type="search"
+              aria-label="Search campaigns"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search campaigns by keyword"
+              className="w-full sm:w-80 rounded-lg border border-neutral-200 px-3 py-2 focus:ring-2 focus:ring-primary-500"
+            />
+            <p className="text-sm text-neutral-600">Total campaigns: <span className="font-semibold text-foreground">{total}</span></p>
+          </div>
           <div />
         </div>
 
@@ -43,14 +66,25 @@ export default function CampaignsPage() {
               <Inbox className="w-10 h-10 text-neutral-300" />
             </div>
             <h3 className="text-2xl font-bold text-neutral-900 mb-2">No campaigns found</h3>
-            <p className="text-neutral-500 text-center max-w-sm mb-8">There are no active campaigns right now. Check back later or explore featured campaigns.</p>
+            <p className="text-neutral-500 text-center max-w-sm mb-8">There are no campaigns matching your search. Try different keywords.</p>
+            <div className="flex gap-2 flex-wrap justify-center mb-6">
+              {['health','education','relief','community','disaster'].map((s) => (
+                <button
+                  key={s}
+                  onClick={() => setSearchTerm(s)}
+                  className="px-3 py-1 rounded-full border border-neutral-200 text-sm text-neutral-700 hover:bg-neutral-50"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
             <Link href="/" className="px-5 py-2 rounded-lg border border-neutral-200 text-sm font-bold">Return Home</Link>
           </div>
         ) : (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
               {campaigns.map((c) => (
-                <ProjectCard key={c.id} project={c as any} />
+                <ProjectCard key={c.id} project={c as any} highlight={debouncedTerm} />
               ))}
             </div>
 

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -25,9 +25,29 @@ export interface ProjectCardProps {
     goal?: number;
     imageUrl?: string;
   };
+  highlight?: string;
 }
 
-export const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
+export const ProjectCard: React.FC<ProjectCardProps> = ({ project, highlight }) => {
+  // helper to render highlighted text
+  function renderHighlighted(text?: string | number, query?: string) {
+    const str = String(text ?? '');
+    if (!query) return <>{str}</>;
+    const escaped = query.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    const parts = str.split(new RegExp(`(${escaped})`, 'gi'));
+    const qLower = query.toLowerCase();
+    return (
+      <>
+        {parts.map((part, i) =>
+          part.toLowerCase() === qLower ? (
+            <mark key={i} className="bg-yellow-200 text-yellow-900 rounded px-0.5">{part}</mark>
+          ) : (
+            <span key={i}>{part}</span>
+          ),
+        )}
+      </>
+    );
+  }
   const { toggleBookmark, isBookmarked } = useBookmarkStore();
 
   return (
@@ -95,7 +115,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
         </div>
         
         <h3 className="text-xl font-bold text-foreground mb-6 group-hover:text-primary transition-colors line-clamp-2">
-          {project.title}
+          {renderHighlighted(project.title, highlight)}
         </h3>
 
         <div className="mt-auto space-y-6">

--- a/hooks/useCampaigns.ts
+++ b/hooks/useCampaigns.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api/client";
+import type { Project } from "@/types/api";
+
+interface ListResponse {
+  data?: Project[];
+  total?: number;
+  meta?: { total?: number };
+}
+
+async function fetchCampaigns(page: number, limit: number) {
+  const res = await apiClient.get<ListResponse>(`/projects`, {
+    params: { status: 'active', page, limit },
+  });
+
+  const payload = res.data as ListResponse | Project[];
+  // support several response shapes
+  const items: Project[] = Array.isArray(payload) ? payload : payload.data ?? [];
+  const total = (payload as ListResponse).total ?? (payload as ListResponse).meta?.total ?? Number(res.headers['x-total-count']) || items.length;
+
+  return { items, total };
+}
+
+export function useCampaigns(page: number, limit: number) {
+  return useQuery({
+    queryKey: ["campaigns", page, limit],
+    queryFn: () => fetchCampaigns(page, limit),
+    keepPreviousData: true,
+    staleTime: 1000 * 60 * 2,
+  });
+}
+
+export default useCampaigns;

--- a/hooks/useCampaigns.ts
+++ b/hooks/useCampaigns.ts
@@ -8,10 +8,11 @@ interface ListResponse {
   meta?: { total?: number };
 }
 
-async function fetchCampaigns(page: number, limit: number) {
-  const res = await apiClient.get<ListResponse>(`/projects`, {
-    params: { status: 'active', page, limit },
-  });
+async function fetchCampaigns(page: number, limit: number, q?: string) {
+  const params: Record<string, any> = { status: 'active', page, limit };
+  if (q && q.trim().length > 0) params.q = q.trim();
+
+  const res = await apiClient.get<ListResponse>(`/projects`, { params });
 
   const payload = res.data as ListResponse | Project[];
   // support several response shapes
@@ -21,10 +22,10 @@ async function fetchCampaigns(page: number, limit: number) {
   return { items, total };
 }
 
-export function useCampaigns(page: number, limit: number) {
+export function useCampaigns(page: number, limit: number, q?: string) {
   return useQuery({
-    queryKey: ["campaigns", page, limit],
-    queryFn: () => fetchCampaigns(page, limit),
+    queryKey: ["campaigns", page, limit, q ?? ""],
+    queryFn: () => fetchCampaigns(page, limit, q),
     keepPreviousData: true,
     staleTime: 1000 * 60 * 2,
   });


### PR DESCRIPTION
Closes #181
implemented a paginated campaigns listing with total count and empty state.

Added: [useCampaigns.ts](https://miniature-xylophone-7vq7746g499x2xv74.github.dev/) — react-query hook fetching active campaigns with total count.
Added: [page.tsx](https://miniature-xylophone-7vq7746g499x2xv74.github.dev/) — client page using [ProjectCard](https://miniature-xylophone-7vq7746g499x2xv74.github.dev/) + [Pagination](https://miniature-xylophone-7vq7746g499x2xv74.github.dev/), displays total, empty state, and pagination (default 12/page).

Closes #182