### PR TITLE
feat: artist profile page, portfolio tab, portfolio management & create/edit forms (#386, #387, #392, #393)

### DIFF
--- a/app/artists/[id]/components/PortfolioTab.tsx
+++ b/app/artists/[id]/components/PortfolioTab.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useAppDispatch, useAppSelector } from '@/app/store/hooks';
+import { selectPublishedPortfolios, selectPortfoliosLoading } from '@/app/features/portfolios/portfoliosSelectors';
+import { fetchArtistPortfolios } from '@/app/features/portfolios/portfoliosThunks';
+import { Skeleton } from '@/app/components/ui/Skeleton';
+import { Image, FolderOpen } from 'lucide-react';
+
+interface PortfolioTabProps {
+  artistId: string;
+}
+
+export default function PortfolioTab({ artistId }: PortfolioTabProps) {
+  const dispatch = useAppDispatch();
+  const portfolios = useAppSelector(selectPublishedPortfolios);
+  const loading = useAppSelector(selectPortfoliosLoading);
+
+  useEffect(() => {
+    if (artistId) {
+      dispatch(fetchArtistPortfolios(artistId));
+    }
+  }, [artistId, dispatch]);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800">
+            <Skeleton className="h-48 w-full rounded-none" />
+            <div className="p-4 space-y-3">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (portfolios.length === 0) {
+    return (
+      <div className="text-center py-16">
+        <div className="w-16 h-16 bg-neutral-100 dark:bg-neutral-800 rounded-full flex items-center justify-center mx-auto mb-4">
+          <FolderOpen className="w-8 h-8 text-neutral-400" />
+        </div>
+        <h3 className="text-lg font-semibold text-neutral-700 dark:text-neutral-300 mb-1">
+          No portfolios yet
+        </h3>
+        <p className="text-neutral-400 dark:text-neutral-500 text-sm max-w-sm mx-auto">
+          This artist hasn&apos;t published any portfolios yet. Check back later!
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {portfolios.map((portfolio) => (
+        <Link
+          key={portfolio.id}
+          href={`/portfolios/${portfolio.id}`}
+          className="group bg-white dark:bg-neutral-900 rounded-2xl overflow-hidden border border-neutral-200 dark:border-neutral-800 hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg transition-all duration-300"
+        >
+          <div className="relative h-48 bg-neutral-100 dark:bg-neutral-800 overflow-hidden">
+            {portfolio.coverImage ? (
+              <img
+                src={portfolio.coverImage}
+                alt={portfolio.title}
+                className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center">
+                <Image className="w-12 h-12 text-neutral-300 dark:text-neutral-600" />
+              </div>
+            )}
+            <div className="absolute top-3 right-3">
+              <span className="px-2.5 py-1 bg-white/90 dark:bg-neutral-900/90 backdrop-blur-sm text-xs font-medium text-neutral-600 dark:text-neutral-300 rounded-full">
+                {portfolio.items?.length || 0} items
+              </span>
+            </div>
+          </div>
+          <div className="p-4">
+            <h3 className="font-semibold text-neutral-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors line-clamp-1">
+              {portfolio.title}
+            </h3>
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1 line-clamp-2">
+              {portfolio.description}
+            </p>
+            {portfolio.tags && portfolio.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-3">
+                {portfolio.tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs rounded-md"
+                  >
+                    {tag}
+                  </span>
+                ))}
+                {portfolio.tags.length > 3 && (
+                  <span className="px-2 py-0.5 text-neutral-400 text-xs">
+                    +{portfolio.tags.length - 3}
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/app/artists/[id]/components/ReviewsTab.tsx
+++ b/app/artists/[id]/components/ReviewsTab.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { MessageSquare } from 'lucide-react';
+
+interface ReviewsTabProps {
+  artistId: string;
+}
+
+export default function ReviewsTab({ artistId: _artistId }: ReviewsTabProps) {
+  return (
+    <div className="text-center py-16">
+      <div className="w-16 h-16 bg-neutral-100 dark:bg-neutral-800 rounded-full flex items-center justify-center mx-auto mb-4">
+        <MessageSquare className="w-8 h-8 text-neutral-400" />
+      </div>
+      <h3 className="text-lg font-semibold text-neutral-700 dark:text-neutral-300 mb-1">
+        No Reviews Yet
+      </h3>
+      <p className="text-neutral-400 dark:text-neutral-500 text-sm max-w-sm mx-auto">
+        Reviews will appear here once clients share their experiences.
+      </p>
+    </div>
+  );
+}

--- a/app/artists/[id]/components/ServicesTab.tsx
+++ b/app/artists/[id]/components/ServicesTab.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Image } from 'lucide-react';
+
+interface ServicesTabProps {
+  artistId: string;
+}
+
+export default function ServicesTab({ artistId: _artistId }: ServicesTabProps) {
+  return (
+    <div className="text-center py-16">
+      <div className="w-16 h-16 bg-neutral-100 dark:bg-neutral-800 rounded-full flex items-center justify-center mx-auto mb-4">
+        <Image className="w-8 h-8 text-neutral-400" />
+      </div>
+      <h3 className="text-lg font-semibold text-neutral-700 dark:text-neutral-300 mb-1">
+        Services Coming Soon
+      </h3>
+      <p className="text-neutral-400 dark:text-neutral-500 text-sm max-w-sm mx-auto">
+        Commission services will be available here. Stay tuned!
+      </p>
+    </div>
+  );
+}

--- a/app/artists/[id]/page.tsx
+++ b/app/artists/[id]/page.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useAppDispatch, useAppSelector } from '@/app/store/hooks';
+import { selectCurrentArtist, selectArtistsLoading, selectArtistsError } from '@/app/features/artists/artistsSelectors';
+import { fetchArtistById } from '@/app/features/artists/artistsThunks';
+import PortfolioTab from './components/PortfolioTab';
+import ServicesTab from './components/ServicesTab';
+import ReviewsTab from './components/ReviewsTab';
+import Button from '@/app/components/ui/Button';
+import { Skeleton } from '@/app/components/ui/Skeleton';
+import { MapPin, Star, ShieldCheck, Briefcase, MessageSquare, Image, Mail } from 'lucide-react';
+
+type TabKey = 'portfolio' | 'services' | 'reviews';
+
+export default function ArtistProfilePage() {
+  const params = useParams();
+  const artistId = params.id as string;
+  const dispatch = useAppDispatch();
+  const artist = useAppSelector(selectCurrentArtist);
+  const loading = useAppSelector(selectArtistsLoading);
+  const error = useAppSelector(selectArtistsError);
+  const [activeTab, setActiveTab] = useState<TabKey>('portfolio');
+
+  useEffect(() => {
+    if (artistId) {
+      dispatch(fetchArtistById(artistId));
+    }
+  }, [artistId, dispatch]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+        <Skeleton className="h-56 w-full rounded-none" />
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 -mt-20 relative z-10">
+          <Skeleton className="w-32 h-32 rounded-full border-4 border-white dark:border-neutral-900" />
+          <div className="mt-4 space-y-3 max-w-lg">
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+            <Skeleton className="h-4 w-48" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !artist) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-neutral-50 dark:bg-neutral-950">
+        <div className="text-center">
+          <div className="w-20 h-20 bg-neutral-200 dark:bg-neutral-800 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Image className="w-10 h-10 text-neutral-400" />
+          </div>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">Artist Not Found</h1>
+          <p className="text-neutral-500 dark:text-neutral-400">
+            {error || "We couldn't find the artist you're looking for."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const tabs: { key: TabKey; label: string; icon: React.ReactNode }[] = [
+    { key: 'portfolio', label: 'Portfolio', icon: <Briefcase className="w-4 h-4" /> },
+    { key: 'services', label: 'Services', icon: <Image className="w-4 h-4" /> },
+    { key: 'reviews', label: 'Reviews', icon: <MessageSquare className="w-4 h-4" /> },
+  ];
+
+  return (
+    <div className="min-h-screen bg-neutral-50 dark:bg-neutral-950">
+      {/* Cover Image */}
+      <div className="relative h-56 sm:h-72 bg-gradient-to-r from-primary-600 via-primary-700 to-secondary-600">
+        {artist.coverImage && (
+          <img
+            src={artist.coverImage}
+            alt={`${artist.name} cover`}
+            className="w-full h-full object-cover"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+      </div>
+
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 -mt-20 relative z-10">
+        {/* Profile Header */}
+        <div className="flex flex-col sm:flex-row sm:items-end gap-4 sm:gap-6">
+          {/* Avatar */}
+          <div className="relative w-32 h-32 sm:w-36 sm:h-36 rounded-full border-4 border-white dark:border-neutral-900 overflow-hidden bg-neutral-200 dark:bg-neutral-700 shadow-lg flex-shrink-0">
+            {artist.avatar ? (
+              <img src={artist.avatar} alt={artist.name} className="w-full h-full object-cover" />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-neutral-400">
+                <Image className="w-12 h-12" />
+              </div>
+            )}
+          </div>
+
+          {/* Name & Info */}
+          <div className="flex-1 pb-2">
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-2xl sm:text-3xl font-bold text-neutral-900 dark:text-white">
+                {artist.name}
+              </h1>
+              {artist.verified && (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 text-xs font-medium rounded-full">
+                  <ShieldCheck className="w-3.5 h-3.5" />
+                  Verified
+                </span>
+              )}
+            </div>
+            {artist.tagline && (
+              <p className="text-neutral-600 dark:text-neutral-400 mt-1 text-lg">{artist.tagline}</p>
+            )}
+            <div className="flex items-center gap-4 mt-2 flex-wrap">
+              <div className="flex items-center gap-1 text-amber-500">
+                <Star className="w-4 h-4 fill-current" />
+                <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                  {artist.rating?.toFixed(1) || '—'}
+                </span>
+                <span className="text-sm text-neutral-400">
+                  ({artist.reviewCount || 0} reviews)
+                </span>
+              </div>
+              {artist.walletAddress && (
+                <span className="text-sm text-neutral-400 flex items-center gap-1">
+                  <MapPin className="w-3.5 h-3.5" />
+                  Stellar Wallet Connected
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* CTA Buttons */}
+          <div className="flex gap-2 sm:pb-2 mt-3 sm:mt-0">
+            <Button variant="primary" size="md">
+              <Mail className="w-4 h-4 mr-2" />
+              Hire Me
+            </Button>
+            <Button variant="outline" size="md">
+              Commission
+            </Button>
+          </div>
+        </div>
+
+        {/* Skills Tags */}
+        {artist.skills && artist.skills.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-5">
+            {artist.skills.map((skill) => (
+              <span
+                key={skill}
+                className="px-3 py-1 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 text-xs font-medium rounded-full"
+              >
+                {skill}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Bio */}
+        {artist.bio && (
+          <p className="mt-4 text-neutral-600 dark:text-neutral-400 leading-relaxed max-w-3xl">
+            {artist.bio}
+          </p>
+        )}
+
+        {/* Tabs Navigation */}
+        <div className="mt-8 border-b border-neutral-200 dark:border-neutral-800">
+          <nav className="flex gap-0 -mb-px" role="tablist">
+            {tabs.map((tab) => (
+              <button
+                key={tab.key}
+                role="tab"
+                aria-selected={activeTab === tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`inline-flex items-center gap-2 px-5 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === tab.key
+                    ? 'border-primary-600 text-primary-600 dark:text-primary-400'
+                    : 'border-transparent text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 hover:border-neutral-300 dark:hover:border-neutral-600'
+                }`}
+              >
+                {tab.icon}
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        {/* Tab Content */}
+        <div className="py-8">
+          {activeTab === 'portfolio' && <PortfolioTab artistId={artistId} />}
+          {activeTab === 'services' && <ServicesTab artistId={artistId} />}
+          {activeTab === 'reviews' && <ReviewsTab artistId={artistId} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/layout/DashboardLayout.tsx
+++ b/app/components/layout/DashboardLayout.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 const sidebarLinks = [
   { name: 'Overview', href: '/dashboard' },
   { name: 'My Campaigns', href: '/dashboard/campaigns' },
+  { name: 'My Portfolios', href: '/dashboard/artist/portfolios' },
   { name: 'Donations', href: '/dashboard/donations' },
   { name: 'Wallet', href: '/dashboard/wallet' },
   { name: 'Settings', href: '/dashboard/settings' },

--- a/app/dashboard/artist/portfolios/[id]/edit/page.tsx
+++ b/app/dashboard/artist/portfolios/[id]/edit/page.tsx
@@ -1,0 +1,344 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useAppDispatch, useAppSelector } from '@/app/store/hooks';
+import { selectCurrentPortfolio, selectPortfoliosLoading } from '@/app/features/portfolios/portfoliosSelectors';
+import { fetchPortfolioById, updatePortfolio } from '@/app/features/portfolios/portfoliosThunks';
+import DashboardLayout from '@/app/components/layout/DashboardLayout';
+import Button from '@/app/components/ui/Button';
+import { Input, Textarea } from '@/app/components/ui/Input';
+import { Skeleton } from '@/app/components/ui/Skeleton';
+import { ArrowLeft, Upload, X, Save } from 'lucide-react';
+import Link from 'next/link';
+
+const CATEGORIES = [
+  'Illustration',
+  'Graphic Design',
+  'Photography',
+  '3D Art',
+  'Animation',
+  'UI/UX Design',
+  'Motion Graphics',
+  'Fine Art',
+  'Street Art',
+  'Digital Art',
+  'Other',
+];
+
+export default function EditPortfolioPage() {
+  const router = useRouter();
+  const params = useParams();
+  const portfolioId = params.id as string;
+  const dispatch = useAppDispatch();
+  const portfolio = useAppSelector(selectCurrentPortfolio);
+  const loading = useAppSelector(selectPortfoliosLoading);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoadingPortfolio, setIsLoadingPortfolio] = useState(true);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [coverImage, setCoverImage] = useState<string | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (portfolioId) {
+      setIsLoadingPortfolio(true);
+      dispatch(fetchPortfolioById(portfolioId)).finally(() => setIsLoadingPortfolio(false));
+    }
+  }, [portfolioId, dispatch]);
+
+  useEffect(() => {
+    if (portfolio) {
+      setTitle(portfolio.title);
+      setDescription(portfolio.description);
+      setCategory(portfolio.category);
+      setTags(portfolio.tags || []);
+      setCoverImage(portfolio.coverImage || null);
+    }
+  }, [portfolio]);
+
+  const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      const tag = tagsInput.trim().replace(/,/g, '');
+      if (tag && !tags.includes(tag) && tags.length < 10) {
+        setTags([...tags, tag]);
+        setTagsInput('');
+      }
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags(tags.filter((t) => t !== tag));
+  };
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        setCoverImage(event.target?.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  }, []);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        setCoverImage(event.target?.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setCoverImage(null);
+  };
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!title.trim()) newErrors.title = 'Title is required';
+    if (!description.trim()) newErrors.description = 'Description is required';
+    if (!category) newErrors.category = 'Category is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = async (status?: 'draft' | 'published') => {
+    if (!validate()) return;
+    setIsSubmitting(true);
+    try {
+      const updateData: Partial<{
+        title: string;
+        description: string;
+        category: string;
+        tags: string[];
+        coverImage?: string;
+        status?: 'draft' | 'published';
+      }> = {
+        title: title.trim(),
+        description: description.trim(),
+        category,
+        tags,
+        coverImage: coverImage || undefined,
+      };
+      if (status) {
+        updateData.status = status;
+      }
+      await dispatch(updatePortfolio({ id: portfolioId, data: updateData })).unwrap();
+      router.push('/dashboard/artist/portfolios');
+    } catch {
+      // Error handled in thunk
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoadingPortfolio) {
+    return (
+      <DashboardLayout>
+        <div className="max-w-3xl space-y-6">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-96" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+          <Skeleton className="h-12 w-full rounded-xl" />
+          <Skeleton className="h-32 w-full rounded-xl" />
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  if (!portfolio && !isLoadingPortfolio) {
+    return (
+      <DashboardLayout>
+        <div className="text-center py-16">
+          <h2 className="text-xl font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
+            Portfolio Not Found
+          </h2>
+          <p className="text-neutral-400 dark:text-neutral-500 mb-6">
+            The portfolio you&apos;re trying to edit doesn&apos;t exist or has been deleted.
+          </p>
+          <Link href="/dashboard/artist/portfolios">
+            <Button variant="primary">Back to Portfolios</Button>
+          </Link>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-3xl">
+        {/* Back Link */}
+        <Link
+          href="/dashboard/artist/portfolios"
+          className="inline-flex items-center gap-2 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Portfolios
+        </Link>
+
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Edit Portfolio</h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-8">
+          Update your portfolio details and settings.
+        </p>
+
+        <div className="space-y-6">
+          {/* Cover Image Upload */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Cover Image
+            </label>
+            {coverImage ? (
+              <div className="relative rounded-xl overflow-hidden h-48 bg-neutral-100 dark:bg-neutral-800">
+                <img src={coverImage} alt="Cover" className="w-full h-full object-cover" />
+                <button
+                  type="button"
+                  onClick={handleRemoveImage}
+                  className="absolute top-3 right-3 p-1.5 bg-white/90 dark:bg-neutral-900/90 backdrop-blur-sm rounded-full text-neutral-600 hover:text-red-600 transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            ) : (
+              <div
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`relative border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer ${
+                  isDragOver
+                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+                    : 'border-neutral-300 dark:border-neutral-600 hover:border-primary-400 dark:hover:border-primary-600'
+                }`}
+              >
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={handleFileSelect}
+                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                />
+                <Upload className="w-10 h-10 text-neutral-400 mx-auto mb-3" />
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  <span className="font-medium text-primary-600 dark:text-primary-400">Click to upload</span> or drag
+                  and drop
+                </p>
+                <p className="text-xs text-neutral-400 mt-1">SVG, PNG, JPG or GIF (max. 5MB)</p>
+              </div>
+            )}
+          </div>
+
+          {/* Title */}
+          <Input
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g., Brand Identity for Tech Startup"
+            error={errors.title}
+          />
+
+          {/* Description */}
+          <Textarea
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Describe your portfolio, the project goals, and your creative process..."
+            rows={4}
+            error={errors.description}
+          />
+
+          {/* Category */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Category
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className={`w-full px-4 py-2.5 border rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all ${
+                errors.category ? 'border-red-500' : 'border-neutral-300 dark:border-neutral-600'
+              }`}
+            >
+              <option value="">Select a category</option>
+              {CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+            {errors.category && <p className="mt-1 text-sm text-red-600">{errors.category}</p>}
+          </div>
+
+          {/* Tags */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Tags
+            </label>
+            <Input
+              value={tagsInput}
+              onChange={(e) => setTagsInput(e.target.value)}
+              onKeyDown={handleAddTag}
+              placeholder="Type a tag and press Enter..."
+              helperText="Press Enter or comma to add a tag. Max 10 tags."
+            />
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-3">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center gap-1 px-3 py-1 bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300 text-sm rounded-full"
+                  >
+                    {tag}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveTag(tag)}
+                      className="hover:text-red-500 transition-colors"
+                    >
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-3 pt-4 border-t border-neutral-200 dark:border-neutral-800">
+            <Button
+              variant="primary"
+              onClick={() => handleSave()}
+              isLoading={isSubmitting}
+              disabled={isSubmitting}
+              leftIcon={<Save className="w-4 h-4" />}
+            >
+              Save Changes
+            </Button>
+            <Link href="/dashboard/artist/portfolios">
+              <Button variant="ghost">Cancel</Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/dashboard/artist/portfolios/new/page.tsx
+++ b/app/dashboard/artist/portfolios/new/page.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAppDispatch } from '@/app/store/hooks';
+import { createPortfolio } from '@/app/features/portfolios/portfoliosThunks';
+import DashboardLayout from '@/app/components/layout/DashboardLayout';
+import Button from '@/app/components/ui/Button';
+import { Input, Textarea } from '@/app/components/ui/Input';
+import { ArrowLeft, Upload, X } from 'lucide-react';
+import Link from 'next/link';
+
+const CATEGORIES = [
+  'Illustration',
+  'Graphic Design',
+  'Photography',
+  '3D Art',
+  'Animation',
+  'UI/UX Design',
+  'Motion Graphics',
+  'Fine Art',
+  'Street Art',
+  'Digital Art',
+  'Other',
+];
+
+export default function NewPortfolioPage() {
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('');
+  const [tagsInput, setTagsInput] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+  const [coverImage, setCoverImage] = useState<string | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      const tag = tagsInput.trim().replace(/,/g, '');
+      if (tag && !tags.includes(tag) && tags.length < 10) {
+        setTags([...tags, tag]);
+        setTagsInput('');
+      }
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setTags(tags.filter((t) => t !== tag));
+  };
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type.startsWith('image/')) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        setCoverImage(event.target?.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  }, []);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        setCoverImage(event.target?.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setCoverImage(null);
+  };
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!title.trim()) newErrors.title = 'Title is required';
+    if (!description.trim()) newErrors.description = 'Description is required';
+    if (!category) newErrors.category = 'Category is required';
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = async (status: 'draft' | 'published') => {
+    if (!validate()) return;
+    setIsSubmitting(true);
+    try {
+      const result = await dispatch(
+        createPortfolio({
+          title: title.trim(),
+          description: description.trim(),
+          category,
+          tags,
+          coverImage: coverImage || undefined,
+          status,
+        })
+      ).unwrap();
+      router.push('/dashboard/artist/portfolios');
+    } catch {
+      // Error handled in thunk
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="max-w-3xl">
+        {/* Back Link */}
+        <Link
+          href="/dashboard/artist/portfolios"
+          className="inline-flex items-center gap-2 text-sm text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 mb-6 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Portfolios
+        </Link>
+
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">Create New Portfolio</h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-8">
+          Showcase your best work to attract clients and commissions.
+        </p>
+
+        <div className="space-y-6">
+          {/* Cover Image Upload */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Cover Image
+            </label>
+            {coverImage ? (
+              <div className="relative rounded-xl overflow-hidden h-48 bg-neutral-100 dark:bg-neutral-800">
+                <img src={coverImage} alt="Cover" className="w-full h-full object-cover" />
+                <button
+                  type="button"
+                  onClick={handleRemoveImage}
+                  className="absolute top-3 right-3 p-1.5 bg-white/90 dark:bg-neutral-900/90 backdrop-blur-sm rounded-full text-neutral-600 hover:text-red-600 transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            ) : (
+              <div
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`relative border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer ${
+                  isDragOver
+                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+                    : 'border-neutral-300 dark:border-neutral-600 hover:border-primary-400 dark:hover:border-primary-600'
+                }`}
+              >
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={handleFileSelect}
+                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                />
+                <Upload className="w-10 h-10 text-neutral-400 mx-auto mb-3" />
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  <span className="font-medium text-primary-600 dark:text-primary-400">Click to upload</span> or drag
+                  and drop
+                </p>
+                <p className="text-xs text-neutral-400 mt-1">SVG, PNG, JPG or GIF (max. 5MB)</p>
+              </div>
+            )}
+          </div>
+
+          {/* Title */}
+          <Input
+            label="Title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g., Brand Identity for Tech Startup"
+            error={errors.title}
+          />
+
+          {/* Description */}
+          <Textarea
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Describe your portfolio, the project goals, and your creative process..."
+            rows={4}
+            error={errors.description}
+          />
+
+          {/* Category */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Category
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className={`w-full px-4 py-2.5 border rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none transition-all ${
+                errors.category ? 'border-red-500' : 'border-neutral-300 dark:border-neutral-600'
+              }`}
+            >
+              <option value="">Select a category</option>
+              {CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat}
+                </option>
+              ))}
+            </select>
+            {errors.category && <p className="mt-1 text-sm text-red-600">{errors.category}</p>}
+          </div>
+
+          {/* Tags */}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Tags
+            </label>
+            <Input
+              value={tagsInput}
+              onChange={(e) => setTagsInput(e.target.value)}
+              onKeyDown={handleAddTag}
+              placeholder="Type a tag and press Enter..."
+              helperText="Press Enter or comma to add a tag. Max 10 tags."
+            />
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-3">
+                {tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="inline-flex items-center gap-1 px-3 py-1 bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300 text-sm rounded-full"
+                  >
+                    {tag}
+                    <button type="button" onClick={() => handleRemoveTag(tag)} className="hover:text-red-500 transition-colors">
+                      <X className="w-3.5 h-3.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-3 pt-4 border-t border-neutral-200 dark:border-neutral-800">
+            <Button
+              variant="primary"
+              onClick={() => handleSave('published')}
+              isLoading={isSubmitting}
+              disabled={isSubmitting}
+            >
+              Publish Portfolio
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleSave('draft')}
+              isLoading={isSubmitting}
+              disabled={isSubmitting}
+            >
+              Save as Draft
+            </Button>
+            <Link href="/dashboard/artist/portfolios">
+              <Button variant="ghost">Cancel</Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/dashboard/artist/portfolios/page.tsx
+++ b/app/dashboard/artist/portfolios/page.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useAppDispatch, useAppSelector } from '@/app/store/hooks';
+import { selectPortfolios, selectPortfoliosLoading } from '@/app/features/portfolios/portfoliosSelectors';
+import { fetchMyPortfolios, deletePortfolio, togglePortfolioStatus } from '@/app/features/portfolios/portfoliosThunks';
+import DashboardLayout from '@/app/components/layout/DashboardLayout';
+import Button from '@/app/components/ui/Button';
+import { Skeleton } from '@/app/components/ui/Skeleton';
+import { Plus, Edit, Trash2, Eye, EyeOff, Image, FolderOpen } from 'lucide-react';
+
+export default function PortfolioManagementPage() {
+  const dispatch = useAppDispatch();
+  const portfolios = useAppSelector(selectPortfolios);
+  const loading = useAppSelector(selectPortfoliosLoading);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    dispatch(fetchMyPortfolios());
+  }, [dispatch]);
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this portfolio? This action cannot be undone.')) return;
+    setDeletingId(id);
+    await dispatch(deletePortfolio(id));
+    setDeletingId(null);
+  };
+
+  const handleToggleStatus = async (id: string, currentStatus: 'draft' | 'published') => {
+    setTogglingId(id);
+    await dispatch(togglePortfolioStatus({ id, currentStatus }));
+    setTogglingId(null);
+  };
+
+  return (
+    <DashboardLayout>
+      <div>
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Portfolios</h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-1">
+              Manage your portfolio collections
+            </p>
+          </div>
+          <Link href="/dashboard/artist/portfolios/new">
+            <Button variant="primary" leftIcon={<Plus className="w-4 h-4" />}>
+              New Portfolio
+            </Button>
+          </Link>
+        </div>
+
+        {/* Loading State */}
+        {loading && portfolios.length === 0 && (
+          <div className="space-y-4">
+            {[...Array(3)].map((_, i) => (
+              <div
+                key={i}
+                className="bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-800 p-6"
+              >
+                <div className="flex gap-4">
+                  <Skeleton className="w-24 h-24 rounded-xl flex-shrink-0" />
+                  <div className="flex-1 space-y-3">
+                    <Skeleton className="h-5 w-48" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!loading && portfolios.length === 0 && (
+          <div className="text-center py-16">
+            <div className="w-20 h-20 bg-neutral-100 dark:bg-neutral-800 rounded-full flex items-center justify-center mx-auto mb-4">
+              <FolderOpen className="w-10 h-10 text-neutral-400" />
+            </div>
+            <h2 className="text-xl font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
+              No portfolios yet
+            </h2>
+            <p className="text-neutral-400 dark:text-neutral-500 max-w-md mx-auto mb-6">
+              Create your first portfolio to showcase your work to potential clients.
+            </p>
+            <Link href="/dashboard/artist/portfolios/new">
+              <Button variant="primary" leftIcon={<Plus className="w-4 h-4" />}>
+                Create Your First Portfolio
+              </Button>
+            </Link>
+          </div>
+        )}
+
+        {/* Portfolio List */}
+        {portfolios.length > 0 && (
+          <div className="space-y-4">
+            {portfolios.map((portfolio) => (
+              <div
+                key={portfolio.id}
+                className="bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-800 p-5 hover:border-neutral-300 dark:hover:border-neutral-700 transition-colors"
+              >
+                <div className="flex flex-col sm:flex-row gap-4">
+                  {/* Cover Image */}
+                  <div className="w-full sm:w-28 h-28 rounded-xl overflow-hidden bg-neutral-100 dark:bg-neutral-800 flex-shrink-0">
+                    {portfolio.coverImage ? (
+                      <img
+                        src={portfolio.coverImage}
+                        alt={portfolio.title}
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <Image className="w-8 h-8 text-neutral-300 dark:text-neutral-600" />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h3 className="text-lg font-semibold text-neutral-900 dark:text-white truncate">
+                          {portfolio.title}
+                        </h3>
+                        <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1 line-clamp-2">
+                          {portfolio.description}
+                        </p>
+                      </div>
+                      <div className="flex-shrink-0 flex items-center gap-2">
+                        {/* Status Badge */}
+                        <span
+                          className={`inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full ${
+                            portfolio.status === 'published'
+                              ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400'
+                              : 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                          }`}
+                        >
+                          {portfolio.status === 'published' ? (
+                            <Eye className="w-3 h-3" />
+                          ) : (
+                            <EyeOff className="w-3 h-3" />
+                          )}
+                          {portfolio.status === 'published' ? 'Published' : 'Draft'}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Metadata */}
+                    <div className="flex flex-wrap items-center gap-3 mt-2 text-xs text-neutral-400">
+                      <span>{portfolio.category || 'Uncategorized'}</span>
+                      <span>·</span>
+                      <span>{portfolio.items?.length || 0} items</span>
+                      <span>·</span>
+                      <span>
+                        Updated{' '}
+                        {new Date(portfolio.updatedAt).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                        })}
+                      </span>
+                    </div>
+
+                    {/* Tags */}
+                    {portfolio.tags && portfolio.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5 mt-3">
+                        {portfolio.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 bg-neutral-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Actions */}
+                    <div className="flex flex-wrap items-center gap-2 mt-4 pt-3 border-t border-neutral-100 dark:border-neutral-800">
+                      <Link href={`/dashboard/artist/portfolios/${portfolio.id}/edit`}>
+                        <Button variant="ghost" size="sm" leftIcon={<Edit className="w-3.5 h-3.5" />}>
+                          Edit
+                        </Button>
+                      </Link>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleToggleStatus(portfolio.id, portfolio.status)}
+                        disabled={togglingId === portfolio.id}
+                        isLoading={togglingId === portfolio.id}
+                        leftIcon={
+                          portfolio.status === 'published' ? (
+                            <EyeOff className="w-3.5 h-3.5" />
+                          ) : (
+                            <Eye className="w-3.5 h-3.5" />
+                          )
+                        }
+                      >
+                        {portfolio.status === 'published' ? 'Unpublish' : 'Publish'}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(portfolio.id)}
+                        disabled={deletingId === portfolio.id}
+                        isLoading={deletingId === portfolio.id}
+                        leftIcon={<Trash2 className="w-3.5 h-3.5" />}
+                        className="text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/app/features/artists/artistsSelectors.ts
+++ b/app/features/artists/artistsSelectors.ts
@@ -1,0 +1,7 @@
+'use client';
+
+import { RootState } from '@/app/store';
+
+export const selectCurrentArtist = (state: RootState) => state.artists.currentArtist;
+export const selectArtistsLoading = (state: RootState) => state.artists.loading;
+export const selectArtistsError = (state: RootState) => state.artists.error;

--- a/app/features/artists/artistsSlice.ts
+++ b/app/features/artists/artistsSlice.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface Artist {
+  id: string;
+  name: string;
+  avatar: string;
+  coverImage: string;
+  tagline: string;
+  bio: string;
+  skills: string[];
+  rating: number;
+  reviewCount: number;
+  verified: boolean;
+  portfolioCount: number;
+  servicesCount: number;
+  walletAddress?: string;
+  portfolioUrl?: string;
+  createdAt: string;
+}
+
+interface ArtistsState {
+  currentArtist: Artist | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: ArtistsState = {
+  currentArtist: null,
+  loading: false,
+  error: null,
+};
+
+const artistsSlice = createSlice({
+  name: 'artists',
+  initialState,
+  reducers: {
+    setCurrentArtist: (state, action: PayloadAction<Artist>) => {
+      state.currentArtist = action.payload;
+      state.error = null;
+    },
+    clearCurrentArtist: (state) => {
+      state.currentArtist = null;
+    },
+    setArtistsLoading: (state, action: PayloadAction<boolean>) => {
+      state.loading = action.payload;
+    },
+    setArtistsError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+      state.loading = false;
+    },
+  },
+});
+
+export const {
+  setCurrentArtist,
+  clearCurrentArtist,
+  setArtistsLoading,
+  setArtistsError,
+} = artistsSlice.actions;
+
+export default artistsSlice.reducer;

--- a/app/features/artists/artistsThunks.ts
+++ b/app/features/artists/artistsThunks.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import api from '@/app/services/api';
+import { setCurrentArtist, setArtistsLoading, setArtistsError } from './artistsSlice';
+
+export const fetchArtistById = createAsyncThunk(
+  'artists/fetchArtistById',
+  async (artistId: string, { dispatch }) => {
+    try {
+      dispatch(setArtistsLoading(true));
+      const response = await api.get(`/artists/${artistId}`);
+      dispatch(setCurrentArtist(response.data));
+      dispatch(setArtistsError(null));
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to fetch artist';
+      dispatch(setArtistsError(message));
+      throw error;
+    } finally {
+      dispatch(setArtistsLoading(false));
+    }
+  }
+);

--- a/app/features/portfolios/portfoliosSelectors.ts
+++ b/app/features/portfolios/portfoliosSelectors.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { RootState } from '@/app/store';
+
+export const selectPortfolios = (state: RootState) => state.portfolios.portfolios;
+export const selectCurrentPortfolio = (state: RootState) => state.portfolios.currentPortfolio;
+export const selectPortfoliosLoading = (state: RootState) => state.portfolios.loading;
+export const selectPortfoliosError = (state: RootState) => state.portfolios.error;
+
+export const selectPublishedPortfolios = (state: RootState) =>
+  state.portfolios.portfolios.filter((p) => p.status === 'published');
+
+export const selectDraftPortfolios = (state: RootState) =>
+  state.portfolios.portfolios.filter((p) => p.status === 'draft');

--- a/app/features/portfolios/portfoliosSlice.ts
+++ b/app/features/portfolios/portfoliosSlice.ts
@@ -1,0 +1,88 @@
+'use client';
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface PortfolioItem {
+  id: string;
+  imageUrl: string;
+  title: string;
+  description?: string;
+}
+
+export interface Portfolio {
+  id: string;
+  artistId: string;
+  title: string;
+  description: string;
+  category: string;
+  tags: string[];
+  coverImage: string;
+  items: PortfolioItem[];
+  status: 'draft' | 'published';
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PortfoliosState {
+  portfolios: Portfolio[];
+  currentPortfolio: Portfolio | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: PortfoliosState = {
+  portfolios: [],
+  currentPortfolio: null,
+  loading: false,
+  error: null,
+};
+
+const portfoliosSlice = createSlice({
+  name: 'portfolios',
+  initialState,
+  reducers: {
+    setPortfolios: (state, action: PayloadAction<Portfolio[]>) => {
+      state.portfolios = action.payload;
+      state.error = null;
+    },
+    addPortfolio: (state, action: PayloadAction<Portfolio>) => {
+      state.portfolios.unshift(action.payload);
+    },
+    updatePortfolioInList: (state, action: PayloadAction<Portfolio>) => {
+      const index = state.portfolios.findIndex((p) => p.id === action.payload.id);
+      if (index !== -1) {
+        state.portfolios[index] = action.payload;
+      }
+    },
+    removePortfolio: (state, action: PayloadAction<string>) => {
+      state.portfolios = state.portfolios.filter((p) => p.id !== action.payload);
+    },
+    setCurrentPortfolio: (state, action: PayloadAction<Portfolio | null>) => {
+      state.currentPortfolio = action.payload;
+    },
+    clearPortfolios: (state) => {
+      state.portfolios = [];
+      state.currentPortfolio = null;
+    },
+    setPortfoliosLoading: (state, action: PayloadAction<boolean>) => {
+      state.loading = action.payload;
+    },
+    setPortfoliosError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload;
+      state.loading = false;
+    },
+  },
+});
+
+export const {
+  setPortfolios,
+  addPortfolio,
+  updatePortfolioInList,
+  removePortfolio,
+  setCurrentPortfolio,
+  clearPortfolios,
+  setPortfoliosLoading,
+  setPortfoliosError,
+} = portfoliosSlice.actions;
+
+export default portfoliosSlice.reducer;

--- a/app/features/portfolios/portfoliosThunks.ts
+++ b/app/features/portfolios/portfoliosThunks.ts
@@ -1,0 +1,169 @@
+'use client';
+
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import api from '@/app/services/api';
+import {
+  setPortfolios,
+  addPortfolio,
+  updatePortfolioInList,
+  removePortfolio,
+  setCurrentPortfolio,
+  setPortfoliosLoading,
+  setPortfoliosError,
+  Portfolio,
+} from './portfoliosSlice';
+import { toastSuccess, toastError } from '@/utils/toast';
+
+interface PortfolioFormData {
+  title: string;
+  description: string;
+  category: string;
+  tags: string[];
+  coverImage?: string;
+  items?: { imageUrl: string; title: string; description?: string }[];
+  status: 'draft' | 'published';
+}
+
+// Fetch all portfolios for the current artist
+export const fetchMyPortfolios = createAsyncThunk(
+  'portfolios/fetchMyPortfolios',
+  async (_, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      const response = await api.get('/portfolios/my');
+      dispatch(setPortfolios(response.data));
+      dispatch(setPortfoliosError(null));
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to fetch portfolios';
+      dispatch(setPortfoliosError(message));
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Fetch published portfolios for a specific artist
+export const fetchArtistPortfolios = createAsyncThunk(
+  'portfolios/fetchArtistPortfolios',
+  async (artistId: string, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      const response = await api.get(`/artists/${artistId}/portfolios`);
+      dispatch(setPortfolios(response.data));
+      dispatch(setPortfoliosError(null));
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to fetch portfolios';
+      dispatch(setPortfoliosError(message));
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Fetch single portfolio by ID
+export const fetchPortfolioById = createAsyncThunk(
+  'portfolios/fetchPortfolioById',
+  async (portfolioId: string, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      const response = await api.get(`/portfolios/${portfolioId}`);
+      dispatch(setCurrentPortfolio(response.data));
+      dispatch(setPortfoliosError(null));
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to fetch portfolio';
+      dispatch(setPortfoliosError(message));
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Create a new portfolio
+export const createPortfolio = createAsyncThunk(
+  'portfolios/createPortfolio',
+  async (data: PortfolioFormData, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      const response = await api.post('/portfolios', data);
+      dispatch(addPortfolio(response.data));
+      dispatch(setPortfoliosError(null));
+      toastSuccess('Portfolio created successfully!');
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to create portfolio';
+      dispatch(setPortfoliosError(message));
+      toastError(message);
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Update an existing portfolio
+export const updatePortfolio = createAsyncThunk(
+  'portfolios/updatePortfolio',
+  async ({ id, data }: { id: string; data: Partial<PortfolioFormData> }, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      const response = await api.patch(`/portfolios/${id}`, data);
+      dispatch(updatePortfolioInList(response.data));
+      dispatch(setCurrentPortfolio(response.data));
+      dispatch(setPortfoliosError(null));
+      toastSuccess('Portfolio updated successfully!');
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to update portfolio';
+      dispatch(setPortfoliosError(message));
+      toastError(message);
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Delete a portfolio
+export const deletePortfolio = createAsyncThunk(
+  'portfolios/deletePortfolio',
+  async (portfolioId: string, { dispatch }) => {
+    try {
+      dispatch(setPortfoliosLoading(true));
+      await api.delete(`/portfolios/${portfolioId}`);
+      dispatch(removePortfolio(portfolioId));
+      dispatch(setPortfoliosError(null));
+      toastSuccess('Portfolio deleted successfully!');
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to delete portfolio';
+      dispatch(setPortfoliosError(message));
+      toastError(message);
+      throw error;
+    } finally {
+      dispatch(setPortfoliosLoading(false));
+    }
+  }
+);
+
+// Toggle portfolio publish status
+export const togglePortfolioStatus = createAsyncThunk(
+  'portfolios/togglePortfolioStatus',
+  async ({ id, currentStatus }: { id: string; currentStatus: 'draft' | 'published' }, { dispatch }) => {
+    try {
+      const newStatus = currentStatus === 'published' ? 'draft' : 'published';
+      const response = await api.patch(`/portfolios/${id}`, { status: newStatus });
+      dispatch(updatePortfolioInList(response.data));
+      toastSuccess(`Portfolio ${newStatus === 'published' ? 'published' : 'unpublished'}!`);
+      return response.data;
+    } catch (error: any) {
+      const message = error?.response?.data?.message || error.message || 'Failed to update portfolio status';
+      toastError(message);
+      throw error;
+    }
+  }
+);

--- a/app/store/rootReducer.ts
+++ b/app/store/rootReducer.ts
@@ -9,6 +9,8 @@ import dashboardReducer from '../features/dashboard/dashboardSlice';
 import adminReducer from '../features/admin/adminSlice';
 import bookmarksReducer from '../features/bookmarks/bookmarksSlice';
 import errorsReducer from '../features/errors/errorSlice';
+import artistsReducer from '../features/artists/artistsSlice';
+import portfoliosReducer from '../features/portfolios/portfoliosSlice';
 
 const rootReducer = combineReducers({
   api: apiReducer,
@@ -19,6 +21,8 @@ const rootReducer = combineReducers({
   admin: adminReducer,
   bookmarks: bookmarksReducer,
   errors: errorsReducer,
+  artists: artistsReducer,
+  portfolios: portfoliosReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
## Summary

This PR implements all 4 issues assigned to @danieloche635-bit:

### #386 - Build artist profile page
- `app/artists/[id]/page.tsx` with cover image, avatar, name, tagline, skills, rating, verified badge
- Tabbed navigation: Portfolio, Services, Reviews
- "Hire Me" and "Commission" CTA buttons
- Loading, error, and empty states

### #387 - Build artist portfolio tab
- `app/artists/[id]/components/PortfolioTab.tsx` 
- Portfolio card grid with cover image, title, description, tags
- Loading skeleton and empty state

### #392 - Build artist portfolio management page
- `app/dashboard/artist/portfolios/page.tsx`
- List own portfolios with published/draft status badges
- Edit, Publish/Unpublish, Delete actions per portfolio
- "New Portfolio" button and empty state

### #393 - Build create/edit portfolio form
- `app/dashboard/artist/portfolios/new/page.tsx` - Create form
- `app/dashboard/artist/portfolios/[id]/edit/page.tsx` - Edit form
- Fields: title, description, category select, tags input
- Drag-and-drop image upload for cover image
- Save as draft or publish immediately
- Form validation

### Infrastructure
- Redux slices, thunks, and selectors for `artists` and `portfolios`
- Registered new reducers in `rootReducer.ts`
- Added "My Portfolios" link to DashboardLayout sidebar
closes #386
closes #387
closes #393
closes #392