### PR TITLE
feat(a11y): add skip-to-content link (#440)

### DIFF
--- a/app/components/layout/DashboardLayout.tsx
+++ b/app/components/layout/DashboardLayout.tsx
@@ -53,7 +53,7 @@ export default function DashboardLayout({ children }: DashboardLayoutProps) {
           </div>
         </div>
       </aside>
-      <main className="flex-1 p-8">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-1 p-8">{children}</main>
     </div>
   );
 }

--- a/app/components/layout/MainLayout.tsx
+++ b/app/components/layout/MainLayout.tsx
@@ -15,7 +15,7 @@ export default function MainLayout({ children, isLoggedIn = false, user }: MainL
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-950">
       <Navbar isLoggedIn={isLoggedIn} user={user} />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" tabIndex={-1} className="flex-1">{children}</main>
       <Footer />
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-[100] focus:rounded-md focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-300"
+        >
+          Skip to main content
+        </a>
         <ReduxProvider>
           <ErrorBoundary>
             <Header />


### PR DESCRIPTION
## Summary

Adds a keyboard-accessible Skip to main content link at the top of every page and tags the existing <main> elements with id="main-content" tabIndex={-1} in both DashboardLayout and MainLayout so the target is reachable across all routes.

## Changes

- app/layout.tsx: render the skip link as the first focusable element of <body>. It is visually hidden via sr-only and becomes visible when it receives keyboard focus.
- app/components/layout/DashboardLayout.tsx: add id="main-content" tabIndex={-1} on the dashboard <main>.
- app/components/layout/MainLayout.tsx: add id="main-content" tabIndex={-1} on the marketplace/landing <main>.

## Notes

- No new dependencies.
- Visual states only on :focus so the link is invisible to mouse users.

Closes #440