### PR TITLE
feat(a11y): add aria-labels to icon-only buttons (#439)

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { Bell } from 'lucide-react';
 import { useAppSelector, useAppDispatch } from '@/app/store/hooks';
 import { selectIsAuthenticated, selectUser } from '@/app/features/auth/authSelectors';
 import { logoutUser } from '@/app/features/auth/authThunks';
@@ -73,7 +74,16 @@ export default function Header() {
 
           <div className="hidden md:flex items-center space-x-4">
             {isAuth ? (
-              <div className="relative">
+              <>
+                <Link
+                  href="/settings/notifications"
+                  prefetch={false}
+                  aria-label="Notifications"
+                  className="p-2 rounded-full text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+                >
+                  <Bell className="h-5 w-5" />
+                </Link>
+                <div className="relative">
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
@@ -142,7 +152,8 @@ export default function Header() {
                     </button>
                   </div>
                 )}
-              </div>
+                </div>
+              </>
             ) : (
               <>
                 <Link

--- a/app/dashboard/messages/[id]/page.tsx
+++ b/app/dashboard/messages/[id]/page.tsx
@@ -105,6 +105,7 @@ export default function MessageThreadPage({ params }: { params: { id: string } }
             />
             <button
               type="submit"
+              aria-label="Send message"
               className="rounded-xl bg-violet-600 px-4 py-2 text-sm font-medium text-white"
             >
               Send

--- a/components/commissions/CommissionDeliveryModal.tsx
+++ b/components/commissions/CommissionDeliveryModal.tsx
@@ -63,7 +63,12 @@ export default function CommissionDeliveryModal({ isOpen, onClose }: CommissionD
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Submit Work</h3>
             <p className="text-sm text-gray-500 dark:text-gray-400">Upload files and send a quick note to your client.</p>
           </div>
-          <button onClick={onClose} className="rounded-full p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-full p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>

--- a/components/wallet/WalletConnectButton.tsx
+++ b/components/wallet/WalletConnectButton.tsx
@@ -86,8 +86,10 @@ export default function WalletConnectButton({ onConnected }: WalletConnectButton
   return (
     <div className="space-y-2">
       <button
+        type="button"
         onClick={handleConnect}
         disabled={loading}
+        aria-label="Connect Stellar wallet"
         className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
       >
         <Wallet className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Audits the icon-only buttons called out in the issue (bell, close, hamburger, send, wallet) and adds descriptive aria-label attributes so screen readers and axe DevTools can identify each control.

## Changes

- app/components/layout/Header.tsx: imports Bell from lucide-react and renders a Notifications button to /settings/notifications with aria-label="Notifications". The existing hamburger button already had aria-label="Toggle menu".
- components/wallet/WalletConnectButton.tsx: adds aria-label="Connect Stellar wallet" to the connect button (icon + text).
- components/commissions/CommissionDeliveryModal.tsx: adds aria-label="Close" to the X close button. (Modal.tsx and Lightbox.tsx already had descriptive labels.)
- app/dashboard/messages/[id]/page.tsx: adds aria-label="Send message" to the Send submit button.

## Notes

- No new dependencies.
- Existing aria-label attributes on app/components/common/Modal.tsx (Close modal) and app/components/common/Lightbox.tsx (Close lightbox, Previous image, Next image) were already present and are unchanged.

Closes #439