### PR TITLE
feat(settings): add notification preferences page (#438)

### DIFF
--- a/app/settings/notifications/page.tsx
+++ b/app/settings/notifications/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+
+type PrefKey = 'commission' | 'payment' | 'review' | 'message';
+
+interface Pref {
+  key: PrefKey;
+  label: string;
+  description: string;
+}
+
+const PREFERENCES: Pref[] = [
+  {
+    key: 'commission',
+    label: 'Commission requests',
+    description: 'Email me when an artist receives a new commission request.',
+  },
+  {
+    key: 'payment',
+    label: 'Payments received',
+    description: 'Notify me whenever a payment reaches my wallet.',
+  },
+  {
+    key: 'review',
+    label: 'Reviews posted',
+    description: 'Tell me when a client leaves a review on my profile.',
+  },
+  {
+    key: 'message',
+    label: 'Messages received',
+    description: 'Alert me when I receive a new direct message.',
+  },
+];
+
+const DEFAULT_PREFS: Record<PrefKey, boolean> = {
+  commission: true,
+  payment: true,
+  review: false,
+  message: true,
+};
+
+export default function NotificationSettingsPage() {
+  const [prefs, setPrefs] = useState<Record<PrefKey, boolean>>(DEFAULT_PREFS);
+  const [saving, setSaving] = useState(false);
+
+  const toggle = (key: PrefKey) => {
+    setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    // Backend API not yet available — mock the save action.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    setSaving(false);
+    toast.success('Notification preferences saved.');
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+          Notification preferences
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Choose which events should send an email to your inbox.
+        </p>
+      </header>
+
+      <div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+        {PREFERENCES.map((pref) => {
+          const enabled = prefs[pref.key];
+          return (
+            <div
+              key={pref.key}
+              className="flex items-start justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-gray-800 dark:bg-gray-950"
+            >
+              <div className="flex-1">
+                <span className="block text-sm font-semibold text-gray-900 dark:text-white">
+                  {pref.label}
+                </span>
+                <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+                  {pref.description}
+                </span>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                aria-label={`Toggle ${pref.label} notifications`}
+                onClick={() => toggle(pref.key)}
+                className={
+                  'relative h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ' +
+                  (enabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-700')
+                }
+              >
+                <span
+                  aria-hidden="true"
+                  className={
+                    'absolute top-0.5 inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ' +
+                    (enabled ? 'translate-x-5' : 'translate-x-0.5')
+                  }
+                />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 flex justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          {saving ? 'Saving...' : 'Save preferences'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/settings/notifications/page.tsx
+++ b/app/settings/notifications/page.tsx
@@ -58,7 +58,11 @@ export default function NotificationSettingsPage() {
   };
 
   return (
-    <div className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="mx-auto max-w-2xl px-4 py-10 sm:px-6 lg:px-8"
+    >
       <header className="mb-8">
         <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
           Notification preferences
@@ -118,6 +122,6 @@ export default function NotificationSettingsPage() {
           {saving ? 'Saving...' : 'Save preferences'}
         </button>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

Adds app/settings/notifications/page.tsx with email notification toggles for the four event types called out in the issue: commission requests, payments received, reviews posted, and messages received. Save action is mocked via a short delay plus a react-hot-toast success message; no backend API is required for this PR.

## Changes

- app/settings/notifications/page.tsx (new):
  - Client component with local state for the four preferences.
  - Each toggle is a button with role="switch", aria-checked, and aria-label="Toggle <name> notifications" for screen-reader support.
  - Visible focus ring (focus:ring-2) so keyboard users can see focus state.
  - Tailwind theming aligns with the existing Profile Settings page (gray borders, blue primary).
  - Save handler resolves a 600ms promise then calls toast.success("Notification preferences saved.").

## Notes

- No new dependencies (react-hot-toast and Tailwind already in package.json).
- The page is wrapped in <main id="main-content" tabIndex={-1}> so the skip-to-content link introduced in PR #1 has a target on this route.

Closes #438