### PR TITLE
Add formatUsdc utility and tests

### DIFF
--- a/lib/utils/formatUsdc.test.ts
+++ b/lib/utils/formatUsdc.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatUsdc } from './formatUsdc';
+
+describe('formatUsdc', () => {
+  it('formats decimal USDC amounts with two fractional digits', () => {
+    expect(formatUsdc(12.5)).toBe('12.50 USDC');
+  });
+
+  it('formats zero with two fractional digits', () => {
+    expect(formatUsdc(0)).toBe('0.00 USDC');
+  });
+
+  it('formats large amounts with group separators', () => {
+    expect(formatUsdc(1000000)).toBe('1,000,000.00 USDC');
+  });
+});

--- a/lib/utils/formatUsdc.ts
+++ b/lib/utils/formatUsdc.ts
@@ -1,0 +1,8 @@
+const usdcFormatter = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+export function formatUsdc(amount: number): string {
+  return `${usdcFormatter.format(amount)} USDC`;
+}


### PR DESCRIPTION
## Summary
- add `lib/utils/formatUsdc.ts` with `formatUsdc(amount: number): string`
- format with fixed two decimal places and `en-US` group separators
- add Vitest coverage for the three cases requested in #445

Fixes #445.

## Validation
- `npm test -- lib/utils/formatUsdc.test.ts` passed: 3 tests
- `npm test` passed: 2 files / 7 tests
- `git diff --check` passed
- `npm run type-check` was attempted, but this repository currently has pre-existing TypeScript errors in `app/page.tsx` and `app/dashboard/payments/PaymentEscrowModal.tsx` unrelated to this utility

Preferred payout: USDC. Please confirm the payout network before an address is posted, since this repository appears Stellar-related.