### PR TITLE
feat(messages): build conversations list page (#417)

### DIFF
--- a/app/dashboard/messages/page.tsx
+++ b/app/dashboard/messages/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import Link from 'next/link';
+import { Search } from 'lucide-react';
+import DashboardLayout from '@/app/components/layout/DashboardLayout';
+
+interface Conversation {
+  id: string;
+  participantName: string;
+  participantInitials: string;
+  lastMessage: string;
+  timestamp: string;
+  unreadCount: number;
+  online: boolean;
+}
+
+const MOCK_CONVERSATIONS: Conversation[] = [
+  {
+    id: '1',
+    participantName: 'Adaeze Okafor',
+    participantInitials: 'AO',
+    lastMessage: 'I can start on the draft this afternoon — does that work for you?',
+    timestamp: '9:42 AM',
+    unreadCount: 2,
+    online: true,
+  },
+  {
+    id: '2',
+    participantName: 'Tunde Bakare',
+    participantInitials: 'TB',
+    lastMessage: 'Thanks, I have sent the revised agreement over for your review.',
+    timestamp: 'Yesterday',
+    unreadCount: 0,
+    online: false,
+  },
+  {
+    id: '3',
+    participantName: 'Ifeoma Adeleke',
+    participantInitials: 'IA',
+    lastMessage: 'Final invoice attached. Let me know once the payment clears.',
+    timestamp: 'Yesterday',
+    unreadCount: 1,
+    online: true,
+  },
+  {
+    id: '4',
+    participantName: 'Chinedu Arts Studio',
+    participantInitials: 'CA',
+    lastMessage: 'Great working with you — happy to take on the next commission.',
+    timestamp: 'Mon',
+    unreadCount: 0,
+    online: false,
+  },
+  {
+    id: '5',
+    participantName: 'Lola Design Co.',
+    participantInitials: 'LD',
+    lastMessage: 'Sketch preview ready for feedback whenever you can take a look.',
+    timestamp: 'Sun',
+    unreadCount: 0,
+    online: false,
+  },
+];
+
+export default function ConversationsListPage() {
+  return (
+    <DashboardLayout>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Messages</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Pick up where you left off with the artists and clients you work with.
+          </p>
+        </header>
+
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            aria-hidden="true"
+          />
+          <input
+            type="search"
+            placeholder="Search conversations"
+            aria-label="Search conversations"
+            className="w-full rounded-xl border border-gray-200 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 outline-none placeholder:text-gray-400 focus:border-violet-500 focus:ring-1 focus:ring-violet-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+          />
+        </div>
+
+        <ul
+          className="divide-y divide-gray-200 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm dark:divide-gray-800 dark:border-gray-800 dark:bg-gray-900"
+          aria-label="Conversations"
+        >
+          {MOCK_CONVERSATIONS.map((conversation) => (
+            <li key={conversation.id}>
+              <Link
+                href={`/dashboard/messages/${conversation.id}`}
+                className="flex items-center gap-4 px-4 py-3 transition-colors hover:bg-gray-50 focus-visible:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 dark:hover:bg-gray-800/60 dark:focus-visible:bg-gray-800/60"
+              >
+                <div className="relative shrink-0">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-full bg-violet-100 text-sm font-semibold text-violet-700 dark:bg-violet-900/40 dark:text-violet-200">
+                    {conversation.participantInitials}
+                  </div>
+                  {conversation.online && (
+                    <span
+                      aria-hidden="true"
+                      className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white bg-emerald-500 dark:border-gray-900"
+                    />
+                  )}
+                </div>
+
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                      {conversation.participantName}
+                    </p>
+                    <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                      {conversation.timestamp}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="truncate text-sm text-gray-600 dark:text-gray-300">
+                      {conversation.lastMessage}
+                    </p>
+                    {conversation.unreadCount > 0 && (
+                      <span
+                        aria-label={`${conversation.unreadCount} unread messages`}
+                        className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-violet-600 px-1.5 text-[11px] font-semibold text-white"
+                      >
+                        {conversation.unreadCount}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary

Adds `app/dashboard/messages/page.tsx` matching the issue: a list of recent conversation threads with avatar/initials, participant name, last message preview, timestamp, unread badge, and online dot. Each row is a `<Link>` to `/dashboard/messages/[id]` (the existing thread detail route). A search input sits above the list.

## Notes

- Uses a 5-entry MOCK conversations array so every interaction in the demo (click any row, observe unread badges varying) works without backend wiring. Replace with `/api/conversations` when that endpoint ships.
- Wrapped in `DashboardLayout` so the existing sidebar stays consistent with the rest of the dashboard.
- `aria-label`s on the search input + list help screen readers distinguish this list from the sidebar Messages link.
- Mobile-friendly: rows stretch to the viewport, tap targets are 44px+, online dot is decorative (`aria-hidden`).

Closes #417